### PR TITLE
Add ability to provide a customer flutter manifest

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,9 +17,11 @@ import (
 var dotSlash = string([]byte{'.', filepath.Separator})
 
 var buildTargetMainDart string
+var buildTargetManifest string
 
 func init() {
 	buildCmd.Flags().StringVarP(&buildTargetMainDart, "target", "t", "lib/main_desktop.dart", "The main entry-point file of the application.")
+	buildCmd.Flags().StringVarP(&buildTargetManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	rootCmd.AddCommand(buildCmd)
 }
 
@@ -80,6 +82,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 	cmdFlutterBuild := exec.Command(flutterBin, "build", "bundle",
 		"--asset-dir", filepath.Join(outputDirectoryPath, "flutter_assets"),
 		"--target", buildTargetMainDart,
+		"--manifest", buildTargetManifest,
 	)
 	cmdFlutterBuild.Stderr = os.Stderr
 	cmdFlutterBuild.Stdout = os.Stdout

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,6 @@ import (
 const defaultObservatoryPort = "50300"
 
 func init() {
-
 	runCmd.Flags().StringVarP(&buildTargetMainDart, "target", "t", "lib/main_desktop.dart", "The main entry-point file of the application.")
 	runCmd.Flags().StringVarP(&buildTargetManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	rootCmd.AddCommand(runCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,9 @@ import (
 const defaultObservatoryPort = "50300"
 
 func init() {
+
 	runCmd.Flags().StringVarP(&buildTargetMainDart, "target", "t", "lib/main_desktop.dart", "The main entry-point file of the application.")
+	runCmd.Flags().StringVarP(&buildTargetManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -54,6 +56,7 @@ func runAndAttach(projectName string, targetOS string) {
 
 	cmdFlutterAttach := exec.Command("flutter", "attach",
 		"--target", buildTargetMainDart,
+		"--manifest", buildTargetManifest,
 		"--debug-port", "50300",
 		"--device-id", "flutter-tester",
 	)


### PR DESCRIPTION
* I use a custom `pubspec.yaml` for desktop version of app. Having an option of setting custom manifest is quite useful
* When no such option is provided, it falls back to default one