### PR TITLE
ecosystem consideration: prefixing files with 'go-'

### DIFF
--- a/assets/app/gitignore
+++ b/assets/app/gitignore
@@ -1,1 +1,2 @@
 build
+.last_goflutter_check

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -23,11 +23,12 @@ var (
 	buildManifest          string
 	buildBranch            string
 	buildDebug             bool
-	buildPath              string
 	buildCachePath         string
 	buildOmitEmbedder      bool
 	buildOmitFlutterBundle bool
 )
+
+const buildPath = "go"
 
 func init() {
 	buildCmd.Flags().StringVarP(&buildTarget, "target", "t", "lib/main_desktop.dart", "The main entry-point file of the application.")
@@ -35,7 +36,6 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master or @v0.20.0 for example)")
 	buildCmd.Flags().BoolVar(&buildDebug, "debug", false, "Build a debug version of the app.")
 	buildCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-	buildCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	rootCmd.AddCommand(buildCmd)
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,6 +24,7 @@ var (
 	buildBranch    string
 	buildDebug     bool
 	buildCachePath string
+	buildPath      string
 )
 
 func init() {
@@ -32,6 +33,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master for example)")
 	buildCmd.Flags().BoolVar(&buildDebug, "debug", false, "Build a debug version of the app.")
 	buildCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+	buildCmd.Flags().StringVarP(&buildPath, "path", "p", "go-desktop", "The path that hover uses to save the 'go-flutter' desktop source code (default is 'go-desktop')")
 	buildCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(buildCmd)
 }
@@ -51,7 +53,7 @@ var buildCmd = &cobra.Command{
 }
 
 func build(projectName string, targetOS string, vmArguments []string) {
-	outputDirectoryPath, err := filepath.Abs(filepath.Join("desktop", "build", "outputs", targetOS))
+	outputDirectoryPath, err := filepath.Abs(filepath.Join(buildPath, "build", "outputs", targetOS))
 	if err != nil {
 		fmt.Printf("hover: Failed to resolve absolute path for output directory: %v\n", err)
 		os.Exit(1)
@@ -160,11 +162,11 @@ func build(projectName string, targetOS string, vmArguments []string) {
 	}
 
 	err = copy.Copy(
-		filepath.Join("desktop", "assets"),
+		filepath.Join(buildPath, "assets"),
 		filepath.Join(outputDirectoryPath, "assets"),
 	)
 	if err != nil {
-		fmt.Printf("hover: Failed to copy desktop/assets: %v\n", err)
+		fmt.Printf("hover: Failed to copy %s/assets: %v\n", buildPath, err)
 		os.Exit(1)
 	}
 
@@ -244,7 +246,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		fmt.Sprintf("-ldflags=%s", strings.Join(ldflags, " ")),
 		dotSlash+"cmd",
 	)
-	cmdGoBuild.Dir = filepath.Join(wd, "desktop")
+	cmdGoBuild.Dir = filepath.Join(wd, buildPath)
 	cmdGoBuild.Env = append(os.Environ(),
 		"GO111MODULE=on",
 		"CGO_LDFLAGS="+cgoLdflags,

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,7 +33,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master for example)")
 	buildCmd.Flags().BoolVar(&buildDebug, "debug", false, "Build a debug version of the app.")
 	buildCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-	buildCmd.Flags().StringVarP(&buildPath, "path", "p", "go-desktop", "The path that hover uses to save the 'go-flutter' desktop source code (default is 'go-desktop')")
+	buildCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	buildCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(buildCmd)
 }
@@ -191,7 +191,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 
 	if buildBranch == "" {
 
-		currentTag, err := enginecache.CurrentGoFlutterTag(wd)
+		currentTag, err := enginecache.CurrentGoFlutterTag(filepath.Join(wd, buildPath))
 		if err != nil {
 			fmt.Printf("hover: %v\n", err)
 			os.Exit(1)
@@ -215,7 +215,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		} else {
 			// when the buildBranch is empty and the currentTag is a release.
 			// Check if the 'go-flutter' needs updates.
-			enginecache.CheckFoGoFlutterUpdate(wd, currentTag)
+			enginecache.CheckFoGoFlutterUpdate(filepath.Join(wd, buildPath), currentTag)
 		}
 
 	} else {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -71,9 +71,9 @@ Fail:
 }
 
 func assertHoverInitialized() {
-	_, err := os.Stat("desktop")
+	_, err := os.Stat(buildPath)
 	if os.IsNotExist(err) {
-		fmt.Println("hover: Directory 'desktop' is missing, did you run `hover init` in this project?")
+		fmt.Println("hover: Directory " + buildPath + " is missing, did you run `hover init` in this project?")
 		os.Exit(1)
 	}
 	if err != nil {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
@@ -73,11 +76,57 @@ Fail:
 func assertHoverInitialized() {
 	_, err := os.Stat(buildPath)
 	if os.IsNotExist(err) {
-		fmt.Println("hover: Directory " + buildPath + " is missing, did you run `hover init` in this project?")
+		if hoverMigration() {
+			return
+		}
+		fmt.Println("hover: Directory '" + buildPath + "' is missing, did you run `hover init` in this project?")
 		os.Exit(1)
 	}
 	if err != nil {
 		fmt.Printf("hover: Failed to detect directory desktop: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func hoverMigration() bool {
+	oldBuildPath := "desktop"
+	file, err := os.Open(filepath.Join(oldBuildPath, "go.mod"))
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	fmt.Println("hover: ⚠ Found older hover directory layout, hover is now expecting a 'go' directory instead of 'desktop'.")
+	fmt.Println("hover: ⚠    To migrate, rename the 'desktop' directory to 'go'.")
+	fmt.Printf("hover:      Let hover do the migration? ")
+
+	if askForConfirmation() {
+		err := os.Rename(oldBuildPath, buildPath)
+		if err != nil {
+			fmt.Printf("hover: Migration failed: %v\n", err)
+			return false
+		}
+		fmt.Printf("hover: Migration success\n")
+		return true
+	}
+
+	return false
+}
+
+// askForConfirmation asks the user for confirmation.
+func askForConfirmation() bool {
+	fmt.Printf("[Y/n]: ")
+	in := bufio.NewReader(os.Stdin)
+	s, err := in.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	if s == "y" || s == "yes" || s == "" {
+		return true
+	}
+	return false
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,10 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultBuildPath = "go"
-
 func init() {
-	initCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	rootCmd.AddCommand(initCmd)
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultBuildPath = "go"
+
 func init() {
+	initCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	rootCmd.AddCommand(initCmd)
 }
 
@@ -28,22 +31,22 @@ var initCmd = &cobra.Command{
 		projectPath := args[0]
 		assertInFlutterProject()
 
-		err := os.Mkdir("go-desktop", 0775)
+		err := os.Mkdir(buildPath, 0775)
 		if err != nil {
 			if os.IsExist(err) {
-				fmt.Println("hover: A file or directory named `go-desktop` already exists. Cannot continue init.")
+				fmt.Println("hover: A file or directory named `" + buildPath + "` already exists. Cannot continue init.")
 				os.Exit(1)
 			}
 		}
 
-		desktopCmdPath := filepath.Join("go-desktop", "cmd")
+		desktopCmdPath := filepath.Join(buildPath, "cmd")
 		err = os.Mkdir(desktopCmdPath, 0775)
 		if err != nil {
 			fmt.Printf("hover: Failed to create `%s`: %v\n", desktopCmdPath, err)
 			os.Exit(1)
 		}
 
-		desktopAssetsPath := filepath.Join("go-desktop", "assets")
+		desktopAssetsPath := filepath.Join(buildPath, "assets")
 		err = os.Mkdir(desktopAssetsPath, 0775)
 		if err != nil {
 			fmt.Printf("hover: Failed to create `%s`: %v\n", desktopAssetsPath, err)
@@ -53,7 +56,7 @@ var initCmd = &cobra.Command{
 		copyAsset("app/main.go", filepath.Join(desktopCmdPath, "main.go"))
 		copyAsset("app/options.go", filepath.Join(desktopCmdPath, "options.go"))
 		copyAsset("app/icon.png", filepath.Join(desktopAssetsPath, "icon.png"))
-		copyAsset("app/gitignore", filepath.Join("go-desktop", ".gitignore"))
+		copyAsset("app/gitignore", filepath.Join(buildPath, ".gitignore"))
 
 		wd, err := os.Getwd()
 		if err != nil {
@@ -61,8 +64,8 @@ var initCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+"/go-desktop")
-		cmdGoModInit.Dir = filepath.Join(wd, "go-desktop")
+		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+buildPath)
+		cmdGoModInit.Dir = filepath.Join(wd, buildPath)
 		cmdGoModInit.Env = append(os.Environ(),
 			"GO111MODULE=on",
 		)
@@ -75,7 +78,7 @@ var initCmd = &cobra.Command{
 		}
 
 		cmdGoModTidy := exec.Command(goBin, "mod", "tidy")
-		cmdGoModTidy.Dir = filepath.Join(wd, "go-desktop")
+		cmdGoModTidy.Dir = filepath.Join(wd, buildPath)
 		fmt.Println(cmdGoModTidy.Dir)
 		cmdGoModTidy.Env = append(os.Environ(),
 			"GO111MODULE=on",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -64,7 +64,7 @@ var initCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+buildPath)
+		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+"/"+buildPath)
 		cmdGoModInit.Dir = filepath.Join(wd, buildPath)
 		cmdGoModInit.Env = append(os.Environ(),
 			"GO111MODULE=on",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,22 +28,22 @@ var initCmd = &cobra.Command{
 		projectPath := args[0]
 		assertInFlutterProject()
 
-		err := os.Mkdir("desktop", 0775)
+		err := os.Mkdir("go-desktop", 0775)
 		if err != nil {
 			if os.IsExist(err) {
-				fmt.Println("hover: A file or directory named `desktop` already exists. Cannot continue init.")
+				fmt.Println("hover: A file or directory named `go-desktop` already exists. Cannot continue init.")
 				os.Exit(1)
 			}
 		}
 
-		desktopCmdPath := filepath.Join("desktop", "cmd")
+		desktopCmdPath := filepath.Join("go-desktop", "cmd")
 		err = os.Mkdir(desktopCmdPath, 0775)
 		if err != nil {
 			fmt.Printf("hover: Failed to create `%s`: %v\n", desktopCmdPath, err)
 			os.Exit(1)
 		}
 
-		desktopAssetsPath := filepath.Join("desktop", "assets")
+		desktopAssetsPath := filepath.Join("go-desktop", "assets")
 		err = os.Mkdir(desktopAssetsPath, 0775)
 		if err != nil {
 			fmt.Printf("hover: Failed to create `%s`: %v\n", desktopAssetsPath, err)
@@ -53,7 +53,7 @@ var initCmd = &cobra.Command{
 		copyAsset("app/main.go", filepath.Join(desktopCmdPath, "main.go"))
 		copyAsset("app/options.go", filepath.Join(desktopCmdPath, "options.go"))
 		copyAsset("app/icon.png", filepath.Join(desktopAssetsPath, "icon.png"))
-		copyAsset("app/gitignore", filepath.Join("desktop", ".gitignore"))
+		copyAsset("app/gitignore", filepath.Join("go-desktop", ".gitignore"))
 
 		wd, err := os.Getwd()
 		if err != nil {
@@ -61,8 +61,8 @@ var initCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+"/desktop")
-		cmdGoModInit.Dir = filepath.Join(wd, "desktop")
+		cmdGoModInit := exec.Command(goBin, "mod", "init", projectPath+"/go-desktop")
+		cmdGoModInit.Dir = filepath.Join(wd, "go-desktop")
 		cmdGoModInit.Env = append(os.Environ(),
 			"GO111MODULE=on",
 		)
@@ -75,7 +75,7 @@ var initCmd = &cobra.Command{
 		}
 
 		cmdGoModTidy := exec.Command(goBin, "mod", "tidy")
-		cmdGoModTidy.Dir = filepath.Join(wd, "desktop")
+		cmdGoModTidy.Dir = filepath.Join(wd, "go-desktop")
 		fmt.Println(cmdGoModTidy.Dir)
 		cmdGoModTidy.Env = append(os.Environ(),
 			"GO111MODULE=on",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,7 +21,7 @@ func init() {
 	runCmd.Flags().StringVarP(&buildManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	runCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master for example)")
 	runCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-	runCmd.Flags().StringVarP(&buildPath, "path", "p", "go-desktop", "The path that hover uses to save the 'go-flutter' desktop source code (default is 'go-desktop')")
+	runCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	runCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,7 +20,6 @@ func init() {
 	runCmd.Flags().StringVarP(&buildManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	runCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master or @v0.20.0 for example)")
 	runCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-	runCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	runCmd.Flags().StringVarP(&runObservatoryPort, "observatory-port", "", "50300", "The observatory port used to connect hover to VM services (hot-reload/debug/..)")
 	runCmd.Flags().BoolVar(&buildOmitEmbedder, "omit-embedder", false, "Don't (re)compile 'go-flutter' source code, useful when only working with Dart code")
 	runCmd.Flags().BoolVar(&buildOmitFlutterBundle, "omit-flutter", false, "Don't (re)compile the current Flutter project, useful when only working with Golang code (plugin)")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,6 +21,7 @@ func init() {
 	runCmd.Flags().StringVarP(&buildManifest, "manifest", "m", "pubspec.yaml", "Flutter manifest file of the application.")
 	runCmd.Flags().StringVarP(&buildBranch, "branch", "b", "", "The 'go-flutter' version to use. (@master for example)")
 	runCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+	runCmd.Flags().StringVarP(&buildPath, "path", "p", "go-desktop", "The path that hover uses to save the 'go-flutter' desktop source code (default is 'go-desktop')")
 	runCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(runCmd)
 }
@@ -44,7 +45,7 @@ var runCmd = &cobra.Command{
 }
 
 func runAndAttach(projectName string, targetOS string) {
-	cmdApp := exec.Command(dotSlash + filepath.Join("desktop", "build", "outputs", targetOS, projectName))
+	cmdApp := exec.Command(dotSlash + filepath.Join(buildPath, "build", "outputs", targetOS, projectName))
 	cmdFlutterAttach := exec.Command("flutter", "attach")
 
 	stdoutApp, err := cmdApp.StdoutPipe()

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	upgradeCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+  upgradeCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	upgradeCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(upgradeCmd)
 }
@@ -63,7 +64,7 @@ func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {
 	}
 
 	cmdGoGetU := exec.Command(goBin, "get", "-u", "github.com/go-flutter-desktop/go-flutter"+buildBranch)
-	cmdGoGetU.Dir = filepath.Join(wd, "desktop")
+	cmdGoGetU.Dir = filepath.Join(wd, buildPath)
 	cmdGoGetU.Env = append(os.Environ(),
 		"GO111MODULE=on",
 		"CGO_LDFLAGS="+cgoLdflags,
@@ -82,7 +83,7 @@ func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {
 	}
 
 	cmdGoModDownload := exec.Command(goBin, "mod", "download")
-	cmdGoModDownload.Dir = filepath.Join(wd, "desktop")
+	cmdGoModDownload.Dir = filepath.Join(wd, buildPath)
 	cmdGoModDownload.Env = append(os.Environ(),
 		"GO111MODULE=on",
 	)
@@ -95,7 +96,7 @@ func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {
 		return
 	}
 
-	currentTag, err := enginecache.CurrentGoFlutterTag(wd)
+	currentTag, err := enginecache.CurrentGoFlutterTag(filepath.Join(wd, buildPath))
 	if err != nil {
 		fmt.Printf("hover: %v\n", err)
 		os.Exit(1)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	upgradeCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-  upgradeCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
+	upgradeCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	upgradeCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(upgradeCmd)
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -13,7 +13,6 @@ import (
 
 func init() {
 	upgradeCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
-	upgradeCmd.Flags().StringVarP(&buildPath, "path", "p", defaultBuildPath, "The path that hover uses to save the 'go-flutter' desktop source code")
 	upgradeCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(upgradeCmd)
 }

--- a/internal/enginecache/version.go
+++ b/internal/enginecache/version.go
@@ -38,7 +38,7 @@ func flutterRequiredEngineVersion() string {
 // fetch the last Github release semver. If the Github semver is more recent
 // than the current one, display the update notice.
 func CheckFoGoFlutterUpdate(wd string, currentTag string) {
-	cachedGoFlutterCheckPath := filepath.Join(wd, "desktop", ".last_goflutter_check")
+	cachedGoFlutterCheckPath := filepath.Join(wd, ".last_goflutter_check")
 	cachedGoFlutterCheckBytes, err := ioutil.ReadFile(cachedGoFlutterCheckPath)
 	if err != nil && !os.IsNotExist(err) {
 		fmt.Printf("hover: Failed to read the go-flutter last update check: %v\n", err)
@@ -114,7 +114,7 @@ func CheckFoGoFlutterUpdate(wd string, currentTag string) {
 
 // CurrentGoFlutterTag retrieve the semver of go-flutter in 'go.mod'
 func CurrentGoFlutterTag(wd string) (currentTag string, err error) {
-	goModPath := filepath.Join(wd, "desktop", "go.mod")
+	goModPath := filepath.Join(wd, "go.mod")
 	goModBytes, err := ioutil.ReadFile(goModPath)
 	if err != nil && !os.IsNotExist(err) {
 		err = errors.Wrap(err, "Failed to read the 'go.mod' file: %v")

--- a/internal/enginecache/version.go
+++ b/internal/enginecache/version.go
@@ -37,8 +37,8 @@ func flutterRequiredEngineVersion() string {
 // for the current project. If the last update comes back to more than X days,
 // fetch the last Github release semver. If the Github semver is more recent
 // than the current one, display the update notice.
-func CheckFoGoFlutterUpdate(wd string, currentTag string) {
-	cachedGoFlutterCheckPath := filepath.Join(wd, ".last_goflutter_check")
+func CheckFoGoFlutterUpdate(goDirectoryPath string, currentTag string) {
+	cachedGoFlutterCheckPath := filepath.Join(goDirectoryPath, ".last_goflutter_check")
 	cachedGoFlutterCheckBytes, err := ioutil.ReadFile(cachedGoFlutterCheckPath)
 	if err != nil && !os.IsNotExist(err) {
 		fmt.Printf("hover: Failed to read the go-flutter last update check: %v\n", err)
@@ -113,8 +113,8 @@ func CheckFoGoFlutterUpdate(wd string, currentTag string) {
 }
 
 // CurrentGoFlutterTag retrieve the semver of go-flutter in 'go.mod'
-func CurrentGoFlutterTag(wd string) (currentTag string, err error) {
-	goModPath := filepath.Join(wd, "go.mod")
+func CurrentGoFlutterTag(goDirectoryPath string) (currentTag string, err error) {
+	goModPath := filepath.Join(goDirectoryPath, "go.mod")
 	goModBytes, err := ioutil.ReadFile(goModPath)
 	if err != nil && !os.IsNotExist(err) {
 		err = errors.Wrap(err, "Failed to read the 'go.mod' file: %v")


### PR DESCRIPTION
Default to use a `go` directory instead of `desktop`.
Add a flag, `--path`, to overwrite the go-flutter directory path.