### PR TITLE
Add packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,27 @@ To start the binary: (replace `yourApplicationName` with your app name)
 ./desktop/build/outputs/linux/yourApplicationName
 ```
 
-It's possible to zip the whole dir `desktop/build/outputs/linux` and ship it to a different machine.
+It's possible to zip the whole dir `desktop/build/outputs/linux` and ship it to a different machine or [package](#package-standalone-application) it and ship it to a different machine or even a software repository.
 
+### Package standalone application
+
+To package the build of your standalone application using for example snapcraft run:
+
+```bash
+hover package snap
+```
+
+To also install the application after packaging it enable the install flag.
+
+```bash
+hover package snap -i
+```
+
+The output will be in `desktop/build/outputs/linux` or windows or darwin depending on your OS.
+
+Currently supported packaging formats are:
+- snap (Linux)
+- deb (Linux)
 
 ## Fonts
 

--- a/assets/app/gitignore
+++ b/assets/app/gitignore
@@ -1,1 +1,3 @@
 build
+**snap
+**deb

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,7 +39,7 @@ var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build a desktop release",
 	Run: func(cmd *cobra.Command, args []string) {
-		projectName := assertInFlutterProject()
+		projectName := assertInFlutterProject().Name
 		assertHoverInitialized()
 
 		// Hardcode target to the current OS (no cross-compile support yet)
@@ -49,13 +49,16 @@ var buildCmd = &cobra.Command{
 	},
 }
 
-func build(projectName string, targetOS string, vmArguments []string) {
+func outputDirectoryPath(targetOS string) string {
 	outputDirectoryPath, err := filepath.Abs(filepath.Join("desktop", "build", "outputs", targetOS))
 	if err != nil {
 		fmt.Printf("hover: Failed to resolve absolute path for output directory: %v\n", err)
 		os.Exit(1)
 	}
+	return outputDirectoryPath
+}
 
+func outputBinaryName(projectName string, targetOS string) string {
 	var outputBinaryName = projectName
 	switch targetOS {
 	case "darwin":
@@ -68,8 +71,15 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		fmt.Printf("hover: Target platform %s is not supported.\n", targetOS)
 		os.Exit(1)
 	}
-	outputBinaryPath := filepath.Join(outputDirectoryPath, outputBinaryName)
+	return outputBinaryName
+}
 
+func outputBinaryPath(projectName string, targetOS string) string {
+	outputBinaryPath := filepath.Join(outputDirectoryPath(targetOS), outputBinaryName(projectName, targetOS))
+	return outputBinaryPath
+}
+
+func build(projectName string, targetOS string, vmArguments []string) {
 	var engineCachePath string
 	if buildCachePath != "" {
 		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath)
@@ -77,15 +87,15 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS)
 	}
 
-	err = os.RemoveAll(outputDirectoryPath)
+	var err = os.RemoveAll(outputDirectoryPath(targetOS))
 	if err != nil {
-		fmt.Printf("hover: failed to clean output directory %s: %v\n", outputDirectoryPath, err)
+		fmt.Printf("hover: failed to clean output directory %s: %v\n", outputDirectoryPath(targetOS), err)
 		os.Exit(1)
 	}
 
-	err = os.MkdirAll(outputDirectoryPath, 0775)
+	err = os.MkdirAll(outputDirectoryPath(targetOS), 0775)
 	if err != nil {
-		fmt.Printf("hover: failed to create output directory %s: %v\n", outputDirectoryPath, err)
+		fmt.Printf("hover: failed to create output directory %s: %v\n", outputDirectoryPath(targetOS), err)
 		os.Exit(1)
 	}
 
@@ -113,7 +123,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 	}
 
 	cmdFlutterBuild := exec.Command(flutterBin, "build", "bundle",
-		"--asset-dir", filepath.Join(outputDirectoryPath, "flutter_assets"),
+		"--asset-dir", filepath.Join(outputDirectoryPath(targetOS), "flutter_assets"),
 		"--target", buildTarget,
 		"--manifest", buildManifest,
 		trackWidgetCreation,
@@ -136,7 +146,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		engineFile = "flutter_engine.dll"
 	}
 
-	outputEngineFile := filepath.Join(outputDirectoryPath, engineFile)
+	outputEngineFile := filepath.Join(outputDirectoryPath(targetOS), engineFile)
 	err = copy.Copy(
 		filepath.Join(engineCachePath, engineFile),
 		outputEngineFile,
@@ -155,7 +165,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 
 	err = copy.Copy(
 		filepath.Join(engineCachePath, "artifacts", "icudtl.dat"),
-		filepath.Join(outputDirectoryPath, "icudtl.dat"),
+		filepath.Join(outputDirectoryPath(targetOS), "icudtl.dat"),
 	)
 	if err != nil {
 		fmt.Printf("hover: Failed to copy icudtl.dat: %v\n", err)
@@ -164,7 +174,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 
 	err = copy.Copy(
 		filepath.Join("desktop", "assets"),
-		filepath.Join(outputDirectoryPath, "assets"),
+		filepath.Join(outputDirectoryPath(targetOS), "assets"),
 	)
 	if err != nil {
 		fmt.Printf("hover: Failed to copy desktop/assets: %v\n", err)
@@ -233,7 +243,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 	ldflags = append(ldflags, fmt.Sprintf("-X main.vmArguments=%s", strings.Join(vmArguments, ";")))
 
 	cmdGoBuild := exec.Command(goBin, "build",
-		"-o", outputBinaryPath,
+		"-o", outputBinaryPath(projectName, targetOS),
 		fmt.Sprintf("-ldflags=%s", strings.Join(ldflags, " ")),
 		dotSlash+"cmd",
 	)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -36,6 +36,7 @@ type PubSpec struct {
 	Name         string
 	Description  string
 	Version      string
+	Author       string
 	Dependencies map[string]interface{}
 }
 
@@ -62,6 +63,11 @@ func assertInFlutterProject() PubSpec {
 		}
 		if _, exists := pubspec.Dependencies["flutter"]; !exists {
 			fmt.Println("hover: Missing `flutter` in pubspec.yaml dependencies list.")
+			goto Fail
+		}
+
+		if pubspec.Author == "" {
+			fmt.Println("hover: Missing `author` in pubspec.yaml.")
 			goto Fail
 		}
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 func init() {
@@ -32,14 +32,17 @@ func initBinaries() {
 	}
 }
 
+type PubSpec struct {
+	Name         string
+	Description  string
+	Version      string
+	Dependencies map[string]interface{}
+}
+
 // assertInFlutterProject asserts this command is executed in a flutter project
 // and returns the project name.
-func assertInFlutterProject() string {
+func assertInFlutterProject() PubSpec {
 	{
-		var pubspec struct {
-			Name         string
-			Dependencies map[string]interface{}
-		}
 		file, err := os.Open("pubspec.yaml")
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -51,6 +54,7 @@ func assertInFlutterProject() string {
 		}
 		defer file.Close()
 
+		var pubspec = PubSpec{}
 		err = yaml.NewDecoder(file).Decode(&pubspec)
 		if err != nil {
 			fmt.Printf("hover: Failed to decode pubspec.yaml: %v\n", err)
@@ -61,13 +65,13 @@ func assertInFlutterProject() string {
 			goto Fail
 		}
 
-		return pubspec.Name
+		return pubspec
 	}
 
 Fail:
 	fmt.Println("hover: This command should be run from the root of your Flutter project.")
 	os.Exit(1)
-	return ""
+	return PubSpec{}
 }
 
 func assertHoverInitialized() {

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func init() {
+	rootCmd.AddCommand(packageCmd)
+	packageCmd.AddCommand(packageSnapcraftCmd)
+}
+
+var packageCmd = &cobra.Command{
+	Use:   "package",
+	Short: "Package a desktop release",
+}
+
+var packageSnapcraftCmd = &cobra.Command{
+	Use:   "snapcraft",
+	Short: "Package a desktop release as snap",
+	Run: func(cmd *cobra.Command, args []string) {
+		projectName := assertInFlutterProject().Name
+		assertHoverInitialized()
+
+		// Hardcode target to the current OS (no cross-compile support yet)
+		targetOS := runtime.GOOS
+
+		packageSnapcraft(projectName, targetOS, nil)
+	},
+}
+
+func packageSnapcraft(projectName string, targetOS string, vmArguments []string) {
+	if targetOS != "linux" {
+		fmt.Println("hover: snapcraft only works on linux")
+		os.Exit(1)
+	}
+	if _, err := os.Stat(outputBinaryPath(projectName, targetOS)); os.IsNotExist(err) {
+		fmt.Println("hover: no build outputs found\nhover: Please run `hover build` first")
+		os.Exit(1)
+	}
+	var snapcraftBin, err = exec.LookPath("snapcraft")
+	if err != nil {
+		fmt.Println("hover: Failed to lookup `snapcraft` executable. Please install snapcraft.\nhttps://tutorials.ubuntu.com/tutorial/create-your-first-snap#1")
+		os.Exit(1)
+	}
+	snapDirectoryPath, err := filepath.Abs(filepath.Join("desktop", "snap"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for snap directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.RemoveAll(snapDirectoryPath)
+	if err != nil {
+		fmt.Printf("hover: failed to clean snap directory %s: %v\n", snapDirectoryPath, err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(snapDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: failed to create snap directory %s: %v\n", snapDirectoryPath, err)
+		os.Exit(1)
+	}
+
+	snapLocalDirectoryPath, err := filepath.Abs(filepath.Join(snapDirectoryPath, "local"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for snap local directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.RemoveAll(snapLocalDirectoryPath)
+	if err != nil {
+		fmt.Printf("hover: failed to clean snap local directory %s: %v\n", snapDirectoryPath, err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(snapLocalDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: failed to create snap local directory %s: %v\n", snapDirectoryPath, err)
+		os.Exit(1)
+	}
+
+	gitignoreFilePath, err := filepath.Abs(filepath.Join(snapDirectoryPath, "..", ".gitignore"))
+	if err != nil {
+		fmt.Printf("hover: failed to create .gitignore file %s: %v\n", gitignoreFilePath, err)
+		os.Exit(1)
+	}
+
+	gitignoreFile, err := os.Create(gitignoreFilePath)
+	gitignoreFile.WriteString("build/\n")
+	gitignoreFile.WriteString("snap/\n")
+	gitignoreFile.Close()
+
+	snapcraftFilePath, err := filepath.Abs(filepath.Join(snapDirectoryPath, "snapcraft.yaml"))
+	if err != nil {
+		fmt.Printf("hover: failed to create snapcraft.yaml file %s: %v\n", snapcraftFilePath, err)
+		os.Exit(1)
+	}
+
+	snapcraftFile, err := os.Create(snapcraftFilePath)
+	snapcraftFile.WriteString("name: " + projectName + "\n")
+	snapcraftFile.WriteString("base: core18\n")
+	snapcraftFile.WriteString("version: '" + assertInFlutterProject().Version + "'\n")
+	snapcraftFile.WriteString("summary: " + assertInFlutterProject().Description + "\n")
+	snapcraftFile.WriteString("description: |\n")
+	snapcraftFile.WriteString("  " + assertInFlutterProject().Description + "\n")
+	snapcraftFile.WriteString("confinement: strict\n")
+	snapcraftFile.WriteString("grade: stable\n")
+	snapcraftFile.WriteString("parts:\n")
+	snapcraftFile.WriteString("  app:\n")
+	snapcraftFile.WriteString("    plugin: dump\n")
+	snapcraftFile.WriteString("    source: build/outputs/linux\n")
+	snapcraftFile.WriteString("    stage-packages:\n")
+	snapcraftFile.WriteString("      - libx11-6\n")
+	snapcraftFile.WriteString("      - libxrandr2\n")
+	snapcraftFile.WriteString("      - libxcursor1\n")
+	snapcraftFile.WriteString("      - libxinerama1\n")
+	snapcraftFile.WriteString("  desktop:\n")
+	snapcraftFile.WriteString("    plugin: dump\n")
+	snapcraftFile.WriteString("    source: snap\n")
+	snapcraftFile.WriteString("apps:\n")
+	snapcraftFile.WriteString("  " + projectName + ":\n")
+	snapcraftFile.WriteString("    command: " + projectName + "\n")
+	snapcraftFile.WriteString("    desktop: local/" + projectName + ".desktop\n")
+	snapcraftFile.Close()
+
+	assetIconFilePath := filepath.Join(snapDirectoryPath, "..", "assets", "icon.png")
+	desktopIconFilePath := filepath.Join(snapLocalDirectoryPath, "icon.png")
+	copy.Copy(assetIconFilePath, desktopIconFilePath)
+	splitProjectName := strings.Split(projectName, "")
+	splitProjectName[0] = strings.ToUpper(splitProjectName[0])
+	titledProjectName := strings.Join(splitProjectName, "")
+	desktopFilePath, err := filepath.Abs(filepath.Join(snapLocalDirectoryPath, projectName+".desktop"))
+	if err != nil {
+		fmt.Printf("hover: failed to create "+projectName+".desktop file %s: %v\n", desktopFilePath, err)
+		os.Exit(1)
+	}
+	desktopFile, err := os.Create(desktopFilePath)
+	desktopFile.WriteString("[Desktop Entry]\n")
+	desktopFile.WriteString("Encoding=UTF-8\n")
+	desktopFile.WriteString("Version=" + assertInFlutterProject().Version + "\n")
+	desktopFile.WriteString("Type=Application\n")
+	desktopFile.WriteString("Terminal=false\n")
+	desktopFile.WriteString("Exec=/" + projectName + "\n")
+	desktopFile.WriteString("Name=" + titledProjectName + "\n")
+	desktopFile.WriteString("Icon=/local/icon.png\n")
+	desktopFile.Close()
+
+	cmdBuildSnap := exec.Command(snapcraftBin)
+	cmdBuildSnap.Dir = filepath.Join(snapDirectoryPath, "..")
+	cmdBuildSnap.Stdout = os.Stdout
+	cmdBuildSnap.Stderr = os.Stderr
+	cmdBuildSnap.Stdin = os.Stdin
+	cmdBuildSnap.Start()
+	cmdBuildSnap.Wait()
+
+	snapFilePath := projectName + "_" + assertInFlutterProject().Version + "_" + runtime.GOARCH + ".snap"
+
+	os.Rename(filepath.Join(snapDirectoryPath, "..", snapFilePath), filepath.Join(outputDirectoryPath(targetOS), snapFilePath))
+}

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -11,9 +11,14 @@ import (
 	"strings"
 )
 
+var install bool
+
 func init() {
 	rootCmd.AddCommand(packageCmd)
-	packageCmd.AddCommand(packageSnapcraftCmd)
+	packageSnapCmd.Flags().BoolVarP(&install, "install", "i", false, "Install the snap after packaging it")
+	packageCmd.AddCommand(packageSnapCmd)
+	packageDebCmd.Flags().BoolVarP(&install, "install", "i", false, "Install the deb after packaging it")
+	packageCmd.AddCommand(packageDebCmd)
 }
 
 var packageCmd = &cobra.Command{
@@ -21,8 +26,10 @@ var packageCmd = &cobra.Command{
 	Short: "Package a desktop release",
 }
 
-var packageSnapcraftCmd = &cobra.Command{
-	Use:   "snapcraft",
+var linuxPackageDependencies = []string{"libx11-6", "libxrandr2", "libxcursor1", "libxinerama1"}
+
+var packageSnapCmd = &cobra.Command{
+	Use:   "snap",
 	Short: "Package a desktop release as snap",
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := assertInFlutterProject().Name
@@ -31,24 +38,43 @@ var packageSnapcraftCmd = &cobra.Command{
 		// Hardcode target to the current OS (no cross-compile support yet)
 		targetOS := runtime.GOOS
 
-		packageSnapcraft(projectName, targetOS, nil)
+		packageSnap(projectName, targetOS)
 	},
 }
 
-func packageSnapcraft(projectName string, targetOS string, vmArguments []string) {
-	if targetOS != "linux" {
-		fmt.Println("hover: snapcraft only works on linux")
-		os.Exit(1)
-	}
+var packageDebCmd = &cobra.Command{
+	Use:   "deb",
+	Short: "Package a desktop release as deb",
+	Run: func(cmd *cobra.Command, args []string) {
+		projectName := assertInFlutterProject().Name
+		assertHoverInitialized()
+
+		// Hardcode target to the current OS (no cross-compile support yet)
+		targetOS := runtime.GOOS
+
+		packageDeb(projectName, targetOS)
+	},
+}
+
+func assertBuildOutputAvailable(projectName string, targetOS string) {
 	if _, err := os.Stat(outputBinaryPath(projectName, targetOS)); os.IsNotExist(err) {
-		fmt.Println("hover: no build outputs found\nhover: Please run `hover build` first")
+		fmt.Println("hover: No build outputs found\nhover: Please run `hover build` first")
 		os.Exit(1)
 	}
+}
+
+func packageSnap(projectName string, targetOS string) {
+	if targetOS != "linux" {
+		fmt.Println("hover: Snap only works on linux")
+		os.Exit(1)
+	}
+	assertBuildOutputAvailable(projectName, targetOS)
 	var snapcraftBin, err = exec.LookPath("snapcraft")
 	if err != nil {
 		fmt.Println("hover: Failed to lookup `snapcraft` executable. Please install snapcraft.\nhttps://tutorials.ubuntu.com/tutorial/create-your-first-snap#1")
 		os.Exit(1)
 	}
+	copyAsset("app/gitignore", filepath.Join("desktop", ".gitignore"))
 	snapDirectoryPath, err := filepath.Abs(filepath.Join("desktop", "snap"))
 	if err != nil {
 		fmt.Printf("hover: Failed to resolve absolute path for snap directory: %v\n", err)
@@ -56,12 +82,12 @@ func packageSnapcraft(projectName string, targetOS string, vmArguments []string)
 	}
 	err = os.RemoveAll(snapDirectoryPath)
 	if err != nil {
-		fmt.Printf("hover: failed to clean snap directory %s: %v\n", snapDirectoryPath, err)
+		fmt.Printf("hover: Failed to clean snap directory %s: %v\n", snapDirectoryPath, err)
 		os.Exit(1)
 	}
 	err = os.MkdirAll(snapDirectoryPath, 0775)
 	if err != nil {
-		fmt.Printf("hover: failed to create snap directory %s: %v\n", snapDirectoryPath, err)
+		fmt.Printf("hover: Failed to create snap directory %s: %v\n", snapDirectoryPath, err)
 		os.Exit(1)
 	}
 
@@ -70,35 +96,23 @@ func packageSnapcraft(projectName string, targetOS string, vmArguments []string)
 		fmt.Printf("hover: Failed to resolve absolute path for snap local directory: %v\n", err)
 		os.Exit(1)
 	}
-	err = os.RemoveAll(snapLocalDirectoryPath)
-	if err != nil {
-		fmt.Printf("hover: failed to clean snap local directory %s: %v\n", snapDirectoryPath, err)
-		os.Exit(1)
-	}
 	err = os.MkdirAll(snapLocalDirectoryPath, 0775)
 	if err != nil {
-		fmt.Printf("hover: failed to create snap local directory %s: %v\n", snapDirectoryPath, err)
+		fmt.Printf("hover: Failed to create snap local directory %s: %v\n", snapDirectoryPath, err)
 		os.Exit(1)
 	}
-
-	gitignoreFilePath, err := filepath.Abs(filepath.Join(snapDirectoryPath, "..", ".gitignore"))
-	if err != nil {
-		fmt.Printf("hover: failed to create .gitignore file %s: %v\n", gitignoreFilePath, err)
-		os.Exit(1)
-	}
-
-	gitignoreFile, err := os.Create(gitignoreFilePath)
-	gitignoreFile.WriteString("build/\n")
-	gitignoreFile.WriteString("snap/\n")
-	gitignoreFile.Close()
 
 	snapcraftFilePath, err := filepath.Abs(filepath.Join(snapDirectoryPath, "snapcraft.yaml"))
 	if err != nil {
-		fmt.Printf("hover: failed to create snapcraft.yaml file %s: %v\n", snapcraftFilePath, err)
+		fmt.Printf("hover: Failed to resolve absolute path for snapcraft.yaml file %s: %v\n", snapcraftFilePath, err)
 		os.Exit(1)
 	}
 
 	snapcraftFile, err := os.Create(snapcraftFilePath)
+	if err != nil {
+		fmt.Printf("hover: Failed to create snapcraft.yaml file %s: %v\n", snapcraftFilePath, err)
+		os.Exit(1)
+	}
 	snapcraftFile.WriteString("name: " + projectName + "\n")
 	snapcraftFile.WriteString("base: core18\n")
 	snapcraftFile.WriteString("version: '" + assertInFlutterProject().Version + "'\n")
@@ -112,31 +126,34 @@ func packageSnapcraft(projectName string, targetOS string, vmArguments []string)
 	snapcraftFile.WriteString("    plugin: dump\n")
 	snapcraftFile.WriteString("    source: build/outputs/linux\n")
 	snapcraftFile.WriteString("    stage-packages:\n")
-	snapcraftFile.WriteString("      - libx11-6\n")
-	snapcraftFile.WriteString("      - libxrandr2\n")
-	snapcraftFile.WriteString("      - libxcursor1\n")
-	snapcraftFile.WriteString("      - libxinerama1\n")
+	for _, dependency := range linuxPackageDependencies {
+		snapcraftFile.WriteString("      - " + dependency + "\n")
+	}
 	snapcraftFile.WriteString("  desktop:\n")
 	snapcraftFile.WriteString("    plugin: dump\n")
 	snapcraftFile.WriteString("    source: snap\n")
+	snapcraftFile.WriteString("  assets:\n")
+	snapcraftFile.WriteString("    plugin: dump\n")
+	snapcraftFile.WriteString("    source: assets\n")
 	snapcraftFile.WriteString("apps:\n")
 	snapcraftFile.WriteString("  " + projectName + ":\n")
 	snapcraftFile.WriteString("    command: " + projectName + "\n")
 	snapcraftFile.WriteString("    desktop: local/" + projectName + ".desktop\n")
 	snapcraftFile.Close()
 
-	assetIconFilePath := filepath.Join(snapDirectoryPath, "..", "assets", "icon.png")
-	desktopIconFilePath := filepath.Join(snapLocalDirectoryPath, "icon.png")
-	copy.Copy(assetIconFilePath, desktopIconFilePath)
 	splitProjectName := strings.Split(projectName, "")
 	splitProjectName[0] = strings.ToUpper(splitProjectName[0])
 	titledProjectName := strings.Join(splitProjectName, "")
 	desktopFilePath, err := filepath.Abs(filepath.Join(snapLocalDirectoryPath, projectName+".desktop"))
 	if err != nil {
-		fmt.Printf("hover: failed to create "+projectName+".desktop file %s: %v\n", desktopFilePath, err)
+		fmt.Printf("hover: Failed to resolve absolute path for desktop file %s: %v\n", desktopFilePath, err)
 		os.Exit(1)
 	}
 	desktopFile, err := os.Create(desktopFilePath)
+	if err != nil {
+		fmt.Printf("hover: Failed to create desktop file %s: %v\n", desktopFilePath, err)
+		os.Exit(1)
+	}
 	desktopFile.WriteString("[Desktop Entry]\n")
 	desktopFile.WriteString("Encoding=UTF-8\n")
 	desktopFile.WriteString("Version=" + assertInFlutterProject().Version + "\n")
@@ -144,9 +161,10 @@ func packageSnapcraft(projectName string, targetOS string, vmArguments []string)
 	desktopFile.WriteString("Terminal=false\n")
 	desktopFile.WriteString("Exec=/" + projectName + "\n")
 	desktopFile.WriteString("Name=" + titledProjectName + "\n")
-	desktopFile.WriteString("Icon=/local/icon.png\n")
+	desktopFile.WriteString("Icon=/icon.png\n")
 	desktopFile.Close()
 
+	fmt.Println("hover: Packaging snap...")
 	cmdBuildSnap := exec.Command(snapcraftBin)
 	cmdBuildSnap.Dir = filepath.Join(snapDirectoryPath, "..")
 	cmdBuildSnap.Stdout = os.Stdout
@@ -155,7 +173,168 @@ func packageSnapcraft(projectName string, targetOS string, vmArguments []string)
 	cmdBuildSnap.Start()
 	cmdBuildSnap.Wait()
 
-	snapFilePath := projectName + "_" + assertInFlutterProject().Version + "_" + runtime.GOARCH + ".snap"
+	outputFilePath := filepath.Join(outputDirectoryPath(targetOS), projectName+"_"+runtime.GOARCH+".snap")
+	os.Rename(filepath.Join(snapDirectoryPath, "..", projectName+"_"+assertInFlutterProject().Version+"_"+runtime.GOARCH+".snap"), outputFilePath)
+	if install {
+		fmt.Println("hover: Installing snap...")
+		var snapBin, err = exec.LookPath("snap")
+		if err != nil {
+			fmt.Println("hover: Failed to lookup `snap` executable. Please install snap.")
+			os.Exit(1)
+		}
+		cmdInstallSnap := exec.Command("/bin/sh", "-c", "sudo "+snapBin+" install "+outputFilePath+" --devmode")
+		cmdInstallSnap.Stdout = os.Stdout
+		cmdInstallSnap.Stderr = os.Stderr
+		cmdInstallSnap.Stdin = os.Stdin
+		cmdInstallSnap.Start()
+		cmdInstallSnap.Wait()
+	}
+}
 
-	os.Rename(filepath.Join(snapDirectoryPath, "..", snapFilePath), filepath.Join(outputDirectoryPath(targetOS), snapFilePath))
+func packageDeb(projectName string, targetOS string) {
+	if targetOS != "linux" {
+		fmt.Println("hover: Deb only works on linux")
+		os.Exit(1)
+	}
+	assertBuildOutputAvailable(projectName, targetOS)
+	var dpkgDebBin, err = exec.LookPath("dpkg-deb")
+	if err != nil {
+		fmt.Println("hover: Failed to lookup `dpkg-deb` executable. Please install dpkg-deb.")
+		os.Exit(1)
+	}
+	copyAsset("app/gitignore", filepath.Join("desktop", ".gitignore"))
+	debDirectoryPath, err := filepath.Abs(filepath.Join("desktop", "deb"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for deb directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.RemoveAll(debDirectoryPath)
+	if err != nil {
+		fmt.Printf("hover: Failed to clean deb directory %s: %v\n", debDirectoryPath, err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(debDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: Failed to create deb directory %s: %v\n", debDirectoryPath, err)
+		os.Exit(1)
+	}
+
+	debDebianDirectoryPath, err := filepath.Abs(filepath.Join(debDirectoryPath, "DEBIAN"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for DEBIAN directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(debDebianDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: Failed to create DEBIAN directory %s: %v\n", debDebianDirectoryPath, err)
+		os.Exit(1)
+	}
+
+	binDirectoryPath, err := filepath.Abs(filepath.Join(debDirectoryPath, "usr", "bin"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for bin directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(binDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: Failed to create bin directory %s: %v\n", binDirectoryPath, err)
+		os.Exit(1)
+	}
+	applicationsDirectoryPath, err := filepath.Abs(filepath.Join(debDirectoryPath, "usr", "share", "applications"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for applications directory: %v\n", err)
+		os.Exit(1)
+	}
+	err = os.MkdirAll(applicationsDirectoryPath, 0775)
+	if err != nil {
+		fmt.Printf("hover: Failed to create applications directory %s: %v\n", applicationsDirectoryPath, err)
+		os.Exit(1)
+	}
+
+	controlFilePath, err := filepath.Abs(filepath.Join(debDebianDirectoryPath, "control"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for control file %s: %v\n", controlFilePath, err)
+		os.Exit(1)
+	}
+
+	controlFile, err := os.Create(controlFilePath)
+	if err != nil {
+		fmt.Printf("hover: Failed to create control file %s: %v\n", controlFilePath, err)
+		os.Exit(1)
+	}
+	controlFile.WriteString("Package: " + projectName + "\n")
+	controlFile.WriteString("Architecture: " + runtime.GOARCH + "\n")
+	controlFile.WriteString("Maintainer: @" + assertInFlutterProject().Author + "\n")
+	controlFile.WriteString("Priority: optional\n")
+	controlFile.WriteString("Version: " + assertInFlutterProject().Version + "\n")
+	controlFile.WriteString("Description: " + assertInFlutterProject().Description + "\n")
+	controlFile.WriteString("Depends: " + strings.Join(linuxPackageDependencies, ",") + "\n")
+	controlFile.Close()
+
+	binFilePath, err := filepath.Abs(filepath.Join(binDirectoryPath, "ginko"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for bin file %s: %v\n", binFilePath, err)
+		os.Exit(1)
+	}
+
+	binFile, err := os.Create(binFilePath)
+	if err != nil {
+		fmt.Printf("hover: Failed to create bin file %s: %v\n", controlFilePath, err)
+		os.Exit(1)
+	}
+	binFile.WriteString("#!/bin/sh\n")
+	binFile.WriteString("/usr/bin/" + projectName + "files/" + projectName + "\n")
+	binFile.Close()
+	os.Chmod(binFilePath, 0777)
+
+	splitProjectName := strings.Split(projectName, "")
+	splitProjectName[0] = strings.ToUpper(splitProjectName[0])
+	titledProjectName := strings.Join(splitProjectName, "")
+	desktopFilePath, err := filepath.Abs(filepath.Join(applicationsDirectoryPath, projectName+".desktop"))
+	if err != nil {
+		fmt.Printf("hover: Failed to resolve absolute path for desktop file %s: %v\n", desktopFilePath, err)
+		os.Exit(1)
+	}
+	desktopFile, err := os.Create(desktopFilePath)
+	if err != nil {
+		fmt.Printf("hover: Failed to create desktop file %s: %v\n", desktopFilePath, err)
+		os.Exit(1)
+	}
+	desktopFile.WriteString("[Desktop Entry]\n")
+	desktopFile.WriteString("Encoding=UTF-8\n")
+	desktopFile.WriteString("Version=" + assertInFlutterProject().Version + "\n")
+	desktopFile.WriteString("Type=Application\n")
+	desktopFile.WriteString("Terminal=false\n")
+	desktopFile.WriteString("Exec=/usr/bin/" + projectName + "\n")
+	desktopFile.WriteString("Name=" + titledProjectName + "\n")
+	desktopFile.WriteString("Icon=/usr/bin/" + projectName + "files/assets/icon.png\n")
+	desktopFile.Close()
+
+	copy.Copy(outputDirectoryPath(targetOS), filepath.Join(binDirectoryPath, projectName+"files"))
+
+	fmt.Println("hover: Packaging deb...")
+	cmdBuildDeb := exec.Command(dpkgDebBin, "--build", "deb")
+	cmdBuildDeb.Dir = filepath.Join(debDirectoryPath, "..")
+	cmdBuildDeb.Stdout = os.Stdout
+	cmdBuildDeb.Stderr = os.Stderr
+	cmdBuildDeb.Stdin = os.Stdin
+	cmdBuildDeb.Start()
+	cmdBuildDeb.Wait()
+
+	outputFilePath := filepath.Join(outputDirectoryPath(targetOS), projectName+"_"+runtime.GOARCH+".deb")
+	os.Rename(filepath.Join(debDirectoryPath, "..", "deb.deb"), outputFilePath)
+	if install {
+		fmt.Println("hover: Installing deb...")
+		var dpkgBin, err = exec.LookPath("dpkg")
+		if err != nil {
+			fmt.Println("hover: Failed to lookup `dpkg` executable. Please install dpkg.")
+			os.Exit(1)
+		}
+		cmdInstallDeb := exec.Command("/bin/sh", "-c", "sudo "+dpkgBin+" -i "+outputFilePath)
+		cmdInstallDeb.Stdout = os.Stdout
+		cmdInstallDeb.Stderr = os.Stderr
+		cmdInstallDeb.Stdin = os.Stdin
+		cmdInstallDeb.Start()
+		cmdInstallDeb.Wait()
+	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Build and start a desktop release, with hot-reload support",
 	Run: func(cmd *cobra.Command, args []string) {
-		projectName := assertInFlutterProject()
+		projectName := assertInFlutterProject().Name
 		assertHoverInitialized()
 
 		// Can only run on host OS


### PR DESCRIPTION
Adds packaging support for Snapcraft and deb packages.
The config files get regenerated every time the command is run to package the snap/deb with the correct version and description of the app.
The produced snap/deb provides the app as a command and adds a .desktop file for convenience.
go-flutter-desktop/go-flutter#207