### PR TITLE
Use GH token to retrieve Flutter engine version

### DIFF
--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -252,6 +252,10 @@ func ValidateOrUpdateEngineAtPath(targetOS string, cachePath string) (engineCach
 		os.Exit(1)
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", githubToken))
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Sometimes (specially on public networks), GitHub could throttle requests to its API.
If user has `GITHUB_TOKEN` on its environment it will be used it to do the request.