### PR TITLE
fix: go 1.13 avoid go PROXY.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -388,7 +388,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		}
 
 		if semver.Prerelease() != "" {
-			log.Infof("Upgrade 'go-flutter' to the latest release")
+			log.Infof("Upgrading 'go-flutter' to the latest release")
 			// no buildBranch provided and currentTag isn't a release,
 			// force update. (same behaviour as previous version of hover).
 			err = upgradeGoFlutter(targetOS, engineCachePath)
@@ -399,7 +399,7 @@ func build(projectName string, targetOS string, vmArguments []string) {
 		} else {
 			// when the buildBranch is empty and the currentTag is a release.
 			// Check if the 'go-flutter' needs updates.
-			versioncheck.CheckFoGoFlutterUpdate(filepath.Join(wd, buildPath), currentTag)
+			versioncheck.CheckForGoFlutterUpdate(filepath.Join(wd, buildPath), currentTag)
 		}
 
 	} else {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -64,9 +64,14 @@ func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {
 		return
 	}
 
+	if buildBranch == "" {
+		buildBranch = "@latest"
+	}
+
 	cmdGoGetU := exec.Command(goBin, "get", "-u", "github.com/go-flutter-desktop/go-flutter"+buildBranch)
 	cmdGoGetU.Dir = filepath.Join(wd, buildPath)
 	cmdGoGetU.Env = append(os.Environ(),
+		"GOPROXY=direct", // github.com/golang/go/issues/32955 (allows '/' in branch name)
 		"GO111MODULE=on",
 		"CGO_LDFLAGS="+cgoLdflags,
 	)
@@ -75,11 +80,7 @@ func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {
 
 	err = cmdGoGetU.Run()
 	if err != nil {
-		versionName := buildBranch
-		if versionName == "" {
-			versionName = "latest"
-		}
-		log.Errorf("Updating go-flutter to %s version failed: %v", versionName, err)
+		log.Errorf("Updating go-flutter to %s version failed: %v", buildBranch, err)
 		return
 	}
 

--- a/internal/versioncheck/version.go
+++ b/internal/versioncheck/version.go
@@ -14,11 +14,11 @@ import (
 	"github.com/tcnksm/go-latest"
 )
 
-// CheckFoGoFlutterUpdate check the last 'go-flutter' timestamp we have cached
+// CheckForGoFlutterUpdate check the last 'go-flutter' timestamp we have cached
 // for the current project. If the last update comes back to more than X days,
 // fetch the last Github release semver. If the Github semver is more recent
 // than the current one, display the update notice.
-func CheckFoGoFlutterUpdate(goDirectoryPath string, currentTag string) {
+func CheckForGoFlutterUpdate(goDirectoryPath string, currentTag string) {
 	cachedGoFlutterCheckPath := filepath.Join(goDirectoryPath, ".last_goflutter_check")
 	cachedGoFlutterCheckBytes, err := ioutil.ReadFile(cachedGoFlutterCheckPath)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
Go 1.13 introduced a proxy for go modules versioning.
This proxy doesn't allow to `go get` package that have '/' in the
version string.

eg `go get github.com/go-flutter-desktop/go-flutter@v0.30.0` works.
But `go get get github.com/go-flutter-desktop/go-flutter@feature/test`
wont because of the '/' after the '@'.

The issue is reported in https://github.com/golang/go/issues/32955
A fix is to by-pass the PROXY by using the `GOPROXY=direct` venv.

Go 1.13 also doesn't fetch '@latest' when the tag is already valid.
This commit sets '@latest' to the version string when needed (hover upgrade)