### PR TITLE
Fix printing download percentage in new line

### DIFF
--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -105,7 +105,7 @@ func printDownloadPercent(done chan chan struct{}, path string, expectedSize int
 		var percent = float64(size) / float64(expectedSize) * 100
 
 		// We use '\033[2K\r' to avoid carriage return, it will print above previous.
-		log.Printf("\033[2K\r %.0f %% / 100 %%", percent)
+		fmt.Printf("\033[2K\r %.0f %% / 100 %%", percent)
 
 		if completedCh != nil {
 			close(completedCh)


### PR DESCRIPTION
After #26 it was like this, when a new file got downloaded:
 0 % / 100 %  
 0 % / 100 %  
 0 % / 100 %  
 1 % / 100 %  
 1 % / 100 %  
 2 % / 100 %  
 2 % / 100 %  
 2 % / 100 %  
 4 % / 100 %  
 4 % / 100 %  
 4 % / 100 %  
 4 % / 100 %  
 6 % / 100 %  
 6 % / 100 %  
 7 % / 100 %  
 7 % / 100 %  
 7 % / 100 %  
 9 % / 100 %  

This PR fixes it.