### PR TITLE
feat: add intermediates directory. Copy file when get plugins and build

### DIFF
--- a/assets/plugin/README.md.dlib.tmpl
+++ b/assets/plugin/README.md.dlib.tmpl
@@ -1,0 +1,14 @@
+The `dlib` folder is used for the plugins which use `cgo`.
+
+If your go-flutter plugin dose't use `cgo`, just ignore this file and the `dlib` folder.
+
+When you need to link prebuild dynamic libraries and frameworks,
+you should copy the prebuild dynamic libraries and frameworks to `dlib`/${os} folder.
+
+`hover plugins get` copy this files to path `./go/build/intermediates` of go-flutter app project.
+`hover run` copy files from `./go/build/intermediates/${targetOS}` to `./go/build/outputs/${targetOS}`.
+And `-L{./go/build/outputs/${targetOS}}` is appended to `cgoLdflags` automatically.
+Also `-F{./go/build/outputs/${targetOS}}` is appended to `cgoLdflags` on Mac OS
+
+Attention: `hover` can't resolve the conflicts
+if two different go-flutter plugins have file with the same name in there dlib folder

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -365,6 +365,7 @@ func buildNormal(targetOS string, vmArguments []string) {
 			os.Exit(1)
 		}
 	}
+	fileutils.CopyDir(build.IntermediatesDirectoryPath(targetOS), build.OutputDirectoryPath(targetOS))
 
 	err := os.MkdirAll(build.OutputDirectoryPath(targetOS), 0775)
 	if err != nil {
@@ -532,13 +533,17 @@ func buildNormal(targetOS string, vmArguments []string) {
 
 func buildEnv(targetOS string, engineCachePath string) []string {
 	var cgoLdflags string
+
+	outputDirPath := build.OutputDirectoryPath(targetOS)
+
 	switch targetOS {
 	case "darwin":
 		cgoLdflags = fmt.Sprintf("-F%s -Wl,-rpath,@executable_path", engineCachePath)
+		cgoLdflags = fmt.Sprintf("%s -F%s -L%s", cgoLdflags, outputDirPath, outputDirPath)
 	case "linux":
-		cgoLdflags = fmt.Sprintf("-L%s", engineCachePath)
+		cgoLdflags = fmt.Sprintf("-L%s -L%s", engineCachePath, outputDirPath)
 	case "windows":
-		cgoLdflags = fmt.Sprintf("-L%s", engineCachePath)
+		cgoLdflags = fmt.Sprintf("-L%s -L%s", engineCachePath, outputDirPath)
 	default:
 		log.Errorf("Target platform %s is not supported, cgo_ldflags not implemented.", targetOS)
 		os.Exit(1)

--- a/cmd/init-plugin.go
+++ b/cmd/init-plugin.go
@@ -52,6 +52,23 @@ var createPluginCmd = &cobra.Command{
 		fileutils.CopyTemplate("plugin/README.md.tmpl", filepath.Join(build.BuildPath, "README.md"), fileutils.AssetsBox, templateData)
 		fileutils.CopyTemplate("plugin/import.go.tmpl.tmpl", filepath.Join(build.BuildPath, "import.go.tmpl"), fileutils.AssetsBox, templateData)
 
+		dlibPath := filepath.Join(build.BuildPath, "dlib")
+		err = os.Mkdir(dlibPath, 0775)
+		if err != nil {
+			log.Errorf("Failed to create '%s' directory: %v", dlibPath, err)
+			os.Exit(1)
+		}
+		fileutils.CopyTemplate("plugin/README.md.dlib.tmpl", filepath.Join(dlibPath, "README.md"), fileutils.AssetsBox, templateData)
+
+		platforms := []string{"darwin", "linux", "windows"}
+		for _, platform := range platforms {
+			platformPath := filepath.Join(dlibPath, platform)
+			err = os.Mkdir(platformPath, 0775)
+			if err != nil {
+				log.Errorf("Failed to create '%s' directory: %v", platformPath, err)
+				os.Exit(1)
+			}
+		}
 		initializeGoModule(vcsPath)
 	},
 }

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -301,6 +301,21 @@ func hoverPluginGet(dryRun bool) bool {
 			autoImportTemplatePath := filepath.Join(dep.pluginGoSource, "import.go.tmpl")
 			fileutils.CopyFile(autoImportTemplatePath, pluginImportOutPath)
 
+			if fileutils.IsDirectory(filepath.Join(dep.pluginGoSource, "dlib")) {
+				dlibPath, err := filepath.Abs(filepath.Join(dep.pluginGoSource, "dlib"))
+				if err != nil {
+					log.Errorf("Failed to resolve absolute path for dlib directory: %v", err)
+					os.Exit(1)
+				}
+
+				intermediatesDirectoryPath, err := filepath.Abs(filepath.Join(build.BuildPath, "build", "intermediates"))
+				if err != nil {
+					log.Errorf("Failed to resolve absolute path for intermediates directory: %v", err)
+					os.Exit(1)
+				}
+				fileutils.CopyDir(dlibPath, intermediatesDirectoryPath)
+			}
+
 			pluginImportStr, err := readPluginGoImport(pluginImportOutPath, dep.name)
 			if err != nil {
 				log.Warnf("Couldn't read the plugin '%s' import URL", dep.name)

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -229,6 +229,16 @@ var pluginTidyCmd = &cobra.Command{
 				}
 			}
 		}
+		if tidyPurge {
+			intermediatesDirectoryPath, err := filepath.Abs(filepath.Join(build.BuildPath, "build", "intermediates"))
+			if err != nil {
+				log.Errorf("Failed to resolve absolute path for intermediates directory: %v", err)
+				os.Exit(1)
+			}
+			if fileutils.IsDirectory(intermediatesDirectoryPath) {
+				_ = os.RemoveAll(intermediatesDirectoryPath)
+			}
+		}
 	},
 }
 

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -323,7 +323,13 @@ func hoverPluginGet(dryRun bool) bool {
 					log.Errorf("Failed to resolve absolute path for intermediates directory: %v", err)
 					os.Exit(1)
 				}
+
 				fileutils.CopyDir(dlibPath, intermediatesDirectoryPath)
+				if fileutils.IsFileExists(filepath.Join(dlibPath, "README.md")) {
+					readmeName := fmt.Sprintf("README-%s.md", dep.name)
+					fileutils.CopyFile(filepath.Join(dlibPath, "README.md"), filepath.Join(intermediatesDirectoryPath, readmeName))
+					_ = os.Remove(filepath.Join(intermediatesDirectoryPath, "README.md"))
+				}
 			}
 
 			pluginImportStr, err := readPluginGoImport(pluginImportOutPath, dep.name)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -11,11 +11,10 @@ import (
 // Much like android and ios are already used.
 const BuildPath = "go"
 
-// OutputDirectoryPath returns the path where the go-flutter binary and flutter
-// binaries blobs will be stored for a particular platform.
+// buildDirectoryPath returns the path in `BuildPath`/build.
 // If needed, the directory is create at the returned path.
-func OutputDirectoryPath(targetOS string) string {
-	outputDirectoryPath, err := filepath.Abs(filepath.Join(BuildPath, "build", "outputs", targetOS))
+func buildDirectoryPath(targetOS, path string) string {
+	outputDirectoryPath, err := filepath.Abs(filepath.Join(BuildPath, "build", path, targetOS))
 	if err != nil {
 		log.Errorf("Failed to resolve absolute path for output directory: %v", err)
 		os.Exit(1)
@@ -28,6 +27,23 @@ func OutputDirectoryPath(targetOS string) string {
 		}
 	}
 	return outputDirectoryPath
+}
+
+// OutputDirectoryPath returns the path where the go-flutter binary and flutter
+// binaries blobs will be stored for a particular platform.
+// If needed, the directory is create at the returned path.
+func OutputDirectoryPath(targetOS string) string {
+	return buildDirectoryPath(targetOS, "outputs")
+}
+
+// IntermediatesDirectoryPath returns the path where the intermediates stored.
+// If needed, the directory is create at the returned path.
+//
+// Those intermediates include the dynamic library dependencies of go-flutter plugins.
+// hover copies these intermediates from flutter plugins folder when `hover plugins get`, and
+// copies to go-flutter's binary output folder before build.
+func IntermediatesDirectoryPath(targetOS string) string {
+	return buildDirectoryPath(targetOS, "intermediates")
 }
 
 // OutputBinaryName returns the string of the executable used to launch the

--- a/internal/fileutils/file.go
+++ b/internal/fileutils/file.go
@@ -5,12 +5,22 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
 	rice "github.com/GeertJohan/go.rice"
 	"github.com/go-flutter-desktop/hover/internal/log"
 )
+
+// IsDirectory check if path exists and is a directory
+func IsDirectory(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}
 
 // RemoveLinesFromFile removes lines to a file if the text is present in the line
 func RemoveLinesFromFile(filePath, text string) {
@@ -84,6 +94,37 @@ func CopyFile(src, to string) {
 	if err != nil {
 		log.Errorf("Failed to copy %s to %s: %v\n", src, to, err)
 		os.Exit(1)
+	}
+}
+
+// CopyDir copy files from one directory to another directory recursively
+func CopyDir(src, dst string) {
+	var err error
+	var fds []os.FileInfo
+
+	if !IsDirectory(src) {
+		log.Errorf("Failed to copy directory, %s not a directory\n", src)
+		os.Exit(1)
+	}
+
+	if err = os.MkdirAll(dst, 0755); err != nil {
+		log.Errorf("Failed to copy directory %s to %s: %v\n", src, dst, err)
+		os.Exit(1)
+	}
+
+	if fds, err = ioutil.ReadDir(src); err != nil {
+		log.Errorf("Failed to list directory %s: %v\n", src, err)
+		os.Exit(1)
+	}
+
+	for _, fd := range fds {
+		srcPath := filepath.Join(src, fd.Name())
+		dstPath := filepath.Join(dst, fd.Name())
+		if fd.IsDir() {
+			CopyDir(srcPath, dstPath)
+		} else {
+			CopyFile(srcPath, dstPath)
+		}
 	}
 }
 

--- a/internal/fileutils/file.go
+++ b/internal/fileutils/file.go
@@ -13,6 +13,16 @@ import (
 	"github.com/go-flutter-desktop/hover/internal/log"
 )
 
+
+// IsFileExists checks if a file exists and is not a directory
+func IsFileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // IsDirectory check if path exists and is a directory
 func IsDirectory(path string) bool {
 	info, err := os.Stat(path)


### PR DESCRIPTION
copy files from plugin's go/dlib folder to intermediates folder
when 'hover plugins get'.

copy files in intermediates to binary output folder before build.

implement and finish #296