### PR TITLE
Fix ld directory not found in docker

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -534,7 +534,7 @@ func buildNormal(targetOS string, vmArguments []string) {
 func buildEnv(targetOS string, engineCachePath string) []string {
 	var cgoLdflags string
 
-	outputDirPath := build.OutputDirectoryPath(targetOS)
+	outputDirPath := filepath.Join("build", "outputs", targetOS)
 
 	switch targetOS {
 	case "darwin":


### PR DESCRIPTION
Fixes `ld: warning: directory not found for option '-F/home/jld3103/***/go/build/outputs/darwin'` when cross-compiling with docker.