### PR TITLE
Fix Android organization name beeing only two elements long

### DIFF
--- a/internal/androidmanifest/android-manifest.go
+++ b/internal/androidmanifest/android-manifest.go
@@ -46,7 +46,10 @@ func AndroidOrganizationName() string {
 		return "hover.failed.to.retrieve.package.name"
 	}
 	javaPackage := strings.Split(androidManifest.Package, ".")
-	orgName := strings.Join(javaPackage[:len(javaPackage)-1], ".")
+	if len(javaPackage) > 2 {
+		javaPackage = javaPackage[:len(javaPackage)-1]
+	}
+	orgName := strings.Join(javaPackage, ".")
 	if orgName == "" {
 		return "hover.failed.to.retrieve.package.name"
 	}


### PR DESCRIPTION
Fixes Android organization name only beein two elements long like this `de.ginko`
Previously this resulted in `de`, but now results in `de.ginko`. This has no effect for Android organization names like `de.ginko.app`.