### PR TITLE
allow specifying engine version

### DIFF
--- a/assets/app/hover.yaml
+++ b/assets/app/hover.yaml
@@ -3,3 +3,4 @@ branch: "" # Change to "@latest" to download the latest go-flutter version on ev
 # cache-path: "/home/YOURUSERNAME/.cache/" #  https://github.com/go-flutter-desktop/go-flutter/issues/184
 # opengl: "none" # Uncomment this line if you have trouble with your OpenGL driver (https://github.com/go-flutter-desktop/go-flutter/issues/272)
 docker: false
+engine-version: "" # change to a engine version commit

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -36,6 +36,7 @@ var (
 	buildOpenGlVersion     string
 	buildDocker            bool
 	buildVersion           string
+	buildEngineVersion     string
 )
 
 const mingwGccBinName = "x86_64-w64-mingw32-gcc"
@@ -47,6 +48,7 @@ var engineCachePath string
 func init() {
 	buildCmd.PersistentFlags().StringVarP(&buildTarget, "target", "t", config.BuildTargetDefault, "The main entry-point file of the application.")
 	buildCmd.PersistentFlags().StringVarP(&buildBranch, "branch", "b", config.BuildBranchDefault, "The 'go-flutter' version to use. (@master or @v0.20.0 for example)")
+	buildCmd.PersistentFlags().StringVar(&buildEngineVersion, "engine-version", config.BuildEngineDefault, "The flutter engine version to use.")
 	buildCmd.PersistentFlags().BoolVar(&buildDebug, "debug", false, "Build a debug version of the app.")
 	buildCmd.PersistentFlags().StringVarP(&buildCachePath, "cache-path", "", config.BuildCachePathDefault, "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
 	buildCmd.PersistentFlags().StringVar(&buildOpenGlVersion, "opengl", config.BuildOpenGlVersionDefault, "The OpenGL version specified here is only relevant for external texture plugin (i.e. video_plugin).\nIf 'none' is provided, texture won't be supported. Note: the Flutter Engine still needs a OpenGL compatible context.")
@@ -348,6 +350,10 @@ func buildNormal(targetOS string, vmArguments []string) {
 	if buildCachePath == config.BuildCachePathDefault && config.GetConfig().CachePath != "" {
 		buildCachePath = config.GetConfig().CachePath
 	}
+	if buildEngineVersion == config.BuildEngineDefault && config.GetConfig().Engine != "" {
+		log.Warnf("changing the engine version can lead to undesirable behavior")
+		buildEngineVersion = config.GetConfig().Engine
+	}
 	if buildOpenGlVersion == config.BuildOpenGlVersionDefault && config.GetConfig().OpenGL != "" {
 		buildOpenGlVersion = config.GetConfig().OpenGL
 	}
@@ -357,14 +363,15 @@ func buildNormal(targetOS string, vmArguments []string) {
 	if buildVersion == "" {
 		buildVersion = pubspec.GetPubSpec().Version
 	}
+
 	checkForMainDesktop()
 	crossCompile = targetOS != runtime.GOOS
 	buildDocker = crossCompile || buildDocker
 
 	if buildCachePath != "" {
-		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath)
+		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath, buildEngineVersion)
 	} else {
-		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS)
+		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS, buildEngineVersion)
 	}
 
 	if !buildOmitFlutterBundle && !buildOmitEmbedder {
@@ -385,7 +392,10 @@ func buildNormal(targetOS string, vmArguments []string) {
 
 	checkFlutterChannel()
 
-	var trackWidgetCreation string
+	var (
+		trackWidgetCreation string
+	)
+
 	if buildDebug {
 		trackWidgetCreation = "--track-widget-creation"
 	}
@@ -403,6 +413,7 @@ func buildNormal(targetOS string, vmArguments []string) {
 		"--target", buildTarget,
 		trackWidgetCreation,
 	)
+
 	cmdFlutterBuild.Stderr = os.Stderr
 	cmdFlutterBuild.Stdout = os.Stdout
 

--- a/cmd/bumpversion.go
+++ b/cmd/bumpversion.go
@@ -39,9 +39,9 @@ var upgradeCmd = &cobra.Command{
 func upgrade(targetOS string) (err error) {
 	var engineCachePath string
 	if buildCachePath != "" {
-		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath)
+		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath, "")
 	} else {
-		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS)
+		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS, "")
 	}
 	return upgradeGoFlutter(targetOS, engineCachePath)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/go-flutter-desktop/hover/internal/config"
 	"io"
 	"os"
 	"os/exec"
@@ -14,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/go-flutter-desktop/hover/internal/build"
+	"github.com/go-flutter-desktop/hover/internal/config"
 	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/go-flutter-desktop/hover/internal/pubspec"
 )
@@ -27,6 +27,7 @@ func init() {
 	runCmd.Flags().StringVarP(&buildTarget, "target", "t", config.BuildTargetDefault, "The main entry-point file of the application.")
 	runCmd.Flags().StringVarP(&buildBranch, "branch", "b", config.BuildBranchDefault, "The 'go-flutter' version to use. (@master or @v0.20.0 for example)")
 	runCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", config.BuildCachePathDefault, "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+	runCmd.PersistentFlags().StringVar(&buildEngineVersion, "engine-version", "", "The flutter engine version to use.")
 	runCmd.Flags().StringVar(&buildOpenGlVersion, "opengl", config.BuildOpenGlVersionDefault, "The OpenGL version specified here is only relevant for external texture plugin (i.e. video_plugin).\nIf 'none' is provided, texture won't be supported. Note: the Flutter Engine still needs a OpenGL compatible context.")
 	runCmd.Flags().StringVar(&runInitialRoute, "route", "", "Which route to load when running the app.")
 	runCmd.Flags().StringVarP(&runObservatoryPort, "observatory-port", "", "50300", "The observatory port used to connect hover to VM services (hot-reload/debug/..)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,9 @@ const BuildBranchDefault = ""
 // BuildCachePathDefault Default go-flutter cache path
 const BuildCachePathDefault = ""
 
+// BuildEngineDefault Default go-flutter engine version
+const BuildEngineDefault = ""
+
 // BuildOpenGlVersionDefault Default OpenGL version for go-flutter
 const BuildOpenGlVersionDefault = "3.3"
 
@@ -29,6 +32,7 @@ type Config struct {
 	Branch    string
 	CachePath string `yaml:"cache-path"`
 	OpenGL    string
+	Engine    string `yaml:"engine-version"`
 	Docker    bool
 }
 

--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -196,7 +196,7 @@ func downloadFile(filepath string, url string) error {
 // ValidateOrUpdateEngineAtPath validates the engine we have cached matches the
 // flutter version, or otherwise downloads a new engine. The engine cache
 // location is set by the the user.
-func ValidateOrUpdateEngineAtPath(targetOS string, cachePath string) (engineCachePath string) {
+func ValidateOrUpdateEngineAtPath(targetOS string, cachePath string, requiredEngineVersion string) (engineCachePath string) {
 	engineCachePath = filepath.Join(cachePath, "hover", "engine", targetOS)
 
 	if strings.Contains(engineCachePath, " ") {
@@ -214,7 +214,9 @@ func ValidateOrUpdateEngineAtPath(targetOS string, cachePath string) (engineCach
 		os.Exit(1)
 	}
 	cachedEngineVersion := string(cachedEngineVersionBytes)
-	requiredEngineVersion := FlutterRequiredEngineVersion()
+	if len(requiredEngineVersion) == 0 {
+		requiredEngineVersion = FlutterRequiredEngineVersion()
+	}
 
 	if cachedEngineVersion != "" {
 		if cachedEngineVersion == requiredEngineVersion {
@@ -394,7 +396,7 @@ func ValidateOrUpdateEngineAtPath(targetOS string, cachePath string) (engineCach
 // ValidateOrUpdateEngine validates the engine we have cached matches the
 // flutter version, or otherwise downloads a new engine. The returned path is
 // that of the engine location.
-func ValidateOrUpdateEngine(targetOS string) (engineCachePath string) {
-	engineCachePath = ValidateOrUpdateEngineAtPath(targetOS, cachePath())
+func ValidateOrUpdateEngine(targetOS string, requiredEngineVersion string) (engineCachePath string) {
+	engineCachePath = ValidateOrUpdateEngineAtPath(targetOS, cachePath(), requiredEngineVersion)
 	return
 }


### PR DESCRIPTION
also improves logging a bit for new users.

main thing is it uses the engine version, not the flutter version... perhaps it should use the flutter version may be easier to use?