### PR TITLE
Use only projectName for Mac .app and add Applications shortcut to dmg to ease the install

### DIFF
--- a/assets/packaging/darwin-pkg/Distribution.tmpl.tmpl
+++ b/assets/packaging/darwin-pkg/Distribution.tmpl.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
 	<title>{{.projectName}}</title>
-	<background alignment="topleft" file="root/Applications/{{.projectName}}-{{`{{.version}}`}}.app/Contents/MacOS/assets/icon.png"/>
+	<background alignment="topleft" file="root/Applications/{{.projectName}}.app/Contents/MacOS/assets/icon.png"/>
 	<choices-outline>
 	    <line choice="choiceBase"/>
     </choices-outline>

--- a/cmd/packaging/darwin-bundle.go
+++ b/cmd/packaging/darwin-bundle.go
@@ -4,14 +4,14 @@ package packaging
 var DarwinBundlePackagingTask = &packagingTask{
 	packagingFormatName: "darwin-bundle",
 	templateFiles: map[string]string{
-		"darwin-bundle/Info.plist.tmpl.tmpl": "{{.projectName}}-{{`{{.version}}`}}.app/Contents/Info.plist.tmpl",
+		"darwin-bundle/Info.plist.tmpl.tmpl": "{{.projectName}}.app/Contents/Info.plist.tmpl",
 	},
 	executableFiles: []string{},
 	dockerfileContent: []string{
 		"FROM ubuntu:bionic",
 		"RUN apt-get update && apt-get install icnsutils -y",
 	},
-	buildOutputDirectory:    "{{.projectName}}-{{.version}}.app/Contents/MacOS",
-	packagingScriptTemplate: "mkdir -p {{.projectName}}-{{.version}}.app/Contents/Resources && png2icns {{.projectName}}-{{.version}}.app/Contents/Resources/icon.icns {{.projectName}}-{{.version}}.app/Contents/MacOS/assets/icon.png",
+	buildOutputDirectory:    "{{.projectName}}.app/Contents/MacOS",
+	packagingScriptTemplate: "mkdir -p {{.projectName}}.app/Contents/Resources && png2icns {{.projectName}}.app/Contents/Resources/icon.icns {{.projectName}}.app/Contents/MacOS/assets/icon.png",
 	outputFileExtension:     "app",
 }

--- a/cmd/packaging/darwin-dmg.go
+++ b/cmd/packaging/darwin-dmg.go
@@ -10,6 +10,6 @@ var DarwinDmgPackagingTask = &packagingTask{
 		"FROM ubuntu:bionic",
 		"RUN apt-get update && apt-get install genisoimage -y ",
 	},
-	packagingScriptTemplate: "genisoimage -V '{{.projectName}}' -D -R -apple -no-pad -o '{{.projectName}}-{{.version}}.dmg' dmgdir",
+	packagingScriptTemplate: "ln -sf /Applications dmgdir/Applications && genisoimage -V '{{.projectName}}' -D -R -apple -no-pad -o '{{.projectName}}-{{.version}}.dmg' dmgdir",
 	outputFileExtension:     "dmg",
 }


### PR DESCRIPTION
First of all thanks for the amazing project!
I am building a simple SaaS app with this and I am impressed with the ease!

This PR changes the darwin-bundle .app directory's name as only projectName (removing the version) because this name is shown in the Launchpad so having the version in that doesn't look good.

Also added a softlink to Applications folder in the dmg file for creating darwin-dmg, so that installation is just dragging the app onto the Applications, which is a common practive with dmg mac app installers.

Would have also loved to also implement better looking dmg installers with background and icons, but that can be a separate PR for later.