### PR TITLE
Fix dlib copying

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -396,6 +396,7 @@ func buildNormal(targetOS string, vmArguments []string) {
 			os.Exit(1)
 		}
 	}
+	copyDlibToIntermediates()
 	fileutils.CopyDir(build.IntermediatesDirectoryPath(targetOS), build.OutputDirectoryPath(targetOS))
 
 	err := os.MkdirAll(build.OutputDirectoryPath(targetOS), 0775)


### PR DESCRIPTION
Previously the libraries where only copied once using `hover plugins get` to the `intermediates` directory and then copied on every build to the `outputs` directory.  
Now the get copied every time. I'm not sure if the intermediates directory is of any use now, but I'd leave it for the `README`.