### PR TITLE
Fix symlink assets

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -469,14 +469,10 @@ func buildNormal(targetOS string, vmArguments []string) {
 		os.Exit(1)
 	}
 
-	err = copy.Copy(
+	fileutils.CopyDir(
 		filepath.Join(build.BuildPath, "assets"),
 		filepath.Join(build.OutputDirectoryPath(targetOS), "assets"),
 	)
-	if err != nil {
-		log.Errorf("Failed to copy %s/assets: %v", build.BuildPath, err)
-		os.Exit(1)
-	}
 
 	if buildOmitEmbedder {
 		// Omit the 'go-flutter' build


### PR DESCRIPTION
Using a symlink asset icon didn't work, because the symlink was copied and not the file that the symlink resolves to. Now it works properly.