### PR TITLE
Version detection

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -86,9 +86,12 @@ func dockerHoverBuild(targetOS string, packagingTask packaging.Task, buildFlags 
 		// intended to be abused and may disappear at any time.
 		dockerArgs = append(dockerArgs, "--env", "HOVER_IN_DOCKER_BUILD_VMARGS="+strings.Join(vmArguments, ","))
 	}
-	// TODO: Use hover container of version of the current running hover.
-	// 		Use debug package to obtain Module info which contains the version.
-	dockerImage := "goflutter/hover:latest"
+
+	version := hoverVersion()
+	if version == "(devel)" {
+		version = "latest"
+	}
+	dockerImage := "goflutter/hover:" + version
 	dockerArgs = append(dockerArgs, dockerImage)
 	targetOSAndPackaging := targetOS
 	if packName := packagingTask.Name(); packName != "" {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -35,15 +35,16 @@ var doctorCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		assertInFlutterProject()
 
-		log.Infof("Running on %s", runtime.GOOS)
+		version := hoverVersion()
+		log.Infof("Hover version %s running on %s", version, runtime.GOOS)
 
 		log.Infof("Sharing flutter version")
-		cmdFlutterDoctor := exec.Command(build.FlutterBin(), "--version")
-		cmdFlutterDoctor.Stderr = os.Stderr
-		cmdFlutterDoctor.Stdout = os.Stdout
-		err := cmdFlutterDoctor.Run()
+		cmdFlutterVersion := exec.Command(build.FlutterBin(), "--version")
+		cmdFlutterVersion.Stderr = os.Stderr
+		cmdFlutterVersion.Stdout = os.Stdout
+		err := cmdFlutterVersion.Run()
 		if err != nil {
-			log.Errorf("Flutter doctor failed: %v", err)
+			log.Errorf("Flutter --version failed: %v", err)
 		}
 
 		engineCommitHash := flutterversion.FlutterRequiredEngineVersion()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"sync"
+
+	"github.com/go-flutter-desktop/hover/internal/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print Hover version information",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return errors.New("No arguments allowed")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		version := hoverVersion()
+		fmt.Printf("Hover %s\n", version)
+	},
+}
+
+var (
+	hoverVersionValue string
+	hoverVersionOnce  sync.Once
+)
+
+func hoverVersion() string {
+	hoverVersionOnce.Do(func() {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			log.Errorf("Cannot obtain version information from hover build. To resolve this, please go-get hover using Go 1.13 or newer.")
+			os.Exit(1)
+		}
+		hoverVersionValue = buildInfo.Main.Version
+	})
+	return hoverVersionValue
+}


### PR DESCRIPTION
Use buildInfo to select a docker container image with the same version as the curently running hover

Also add the `hover version` subcommand.