### PR TITLE
Skip AssertInitialized for darwin-dmg

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd into a flutter project.
 cd projects/simpleApplication
 ```
 
-The first time you use hover for a project, you'll need to initialize the project for desktop. An argument can be passed to `hover init` to set the project path. This is usually the path for your project on github or a self-hosted git service. _If you are unsure, use `hover init`, the generated path can always be changed later._
+The first time you use hover for a project, you'll need to initialize the project for use with hover. An argument can be passed to `hover init` to set the project path. This is usually the path for your project on github or a self-hosted git service. _If you are unsure use `hover init` without a path. You can change the path later._
 
 ```bash
 hover init github.com/my-organization/simpleApplication
@@ -55,6 +55,7 @@ Make sure you have the following
 [main_desktop.dart](https://github.com/go-flutter-desktop/examples/blob/5508a59ff4916fca9c05dfde4929d8848fd2a947/pointer_demo/lib/main_desktop.dart)
 in the root librairie of your application.  
 It's the following code before `runApp(..)` that makes Flutter run on other platforms:
+
 ```dart
 debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
 ```

--- a/cmd/packaging/darwin-dmg.go
+++ b/cmd/packaging/darwin-dmg.go
@@ -9,4 +9,5 @@ var DarwinDmgTask = &packagingTask{
 	packagingScriptTemplate:   "ln -sf /Applications dmgdir/Applications && genisoimage -V '{{.projectName}}' -D -R -apple -no-pad -o '{{.projectName}}-{{.version}}.dmg' dmgdir",
 	outputFileExtension:       "dmg",
 	outputFileContainsVersion: true,
+	skipAssertInitialized:     true,
 }

--- a/cmd/packaging/packaging.go
+++ b/cmd/packaging/packaging.go
@@ -126,6 +126,7 @@ type packagingTask struct {
 	packagingScriptTemplate        string                         // Template for the command that actually packages the app
 	outputFileExtension            string                         // File extension of the packaged app
 	outputFileContainsVersion      bool                           // Whether the output file name contains the version
+	skipAssertInitialized          bool                           // Set to true when a task doesn't need to be initialized.
 }
 
 func (t *packagingTask) Name() string {
@@ -232,6 +233,9 @@ func (t *packagingTask) Pack(buildVersion string) {
 }
 
 func (t *packagingTask) AssertInitialized() {
+	if t.skipAssertInitialized {
+		return
+	}
 	if !t.IsInitialized() {
 		log.Errorf("%s is not initialized for packaging. Please run `hover init-packaging %s` first.", t.packagingFormatName, t.packagingFormatName)
 		os.Exit(1)


### PR DESCRIPTION
Skip packaging initialized check for darwin-dmg, it doesn't need to be initialized.

I had an issue with building darwin-dmg in the CI/CD. The darwin-dmg folder is now initialized to be empty (previously there was the Dockerfile). Empty directories are not added to the git index, and therefore not checked out on the CI/CD runner. Hover complained that darwin-dmg wasn't initialized since the go/packaging/darwin-dmg directory didn't exists, but ofcourse this is not needed.