### PR TITLE
Add automatic tool detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ RUN git clone --single-branch --depth=1 --branch 0.2 https://github.com/hogliux/
 FROM ubuntu:bionic as appimagebuilder
 RUN apt-get update \
 	&& apt-get install -y \
-	    curl
+	    wget
 RUN cd /opt \
-	&& curl -LO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+	&& wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2) \
+	&& mv appimagetool-*-x86_64.AppImage appimagetool-x86_64.AppImage \
 	&& chmod a+x appimagetool-x86_64.AppImage \
 	&& sed 's|AI\x02|\x00\x00\x00|g' -i appimagetool-x86_64.AppImage \
 	&& ./appimagetool-x86_64.AppImage --appimage-extract \

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -178,6 +178,9 @@ var buildWindowsMsiCmd = &cobra.Command{
 func subcommandBuild(targetOS string, packagingTask packaging.Task) {
 	assertHoverInitialized()
 	packagingTask.AssertInitialized()
+	if !buildDocker {
+		packagingTask.AssertSupported()
+	}
 
 	if !buildSkipFlutterBuildBundle {
 		cleanBuildOutputsDir(targetOS)

--- a/cmd/packaging/darwin-bundle.go
+++ b/cmd/packaging/darwin-bundle.go
@@ -1,15 +1,37 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
 // DarwinBundleTask packaging for darwin as bundle
 var DarwinBundleTask = &packagingTask{
 	packagingFormatName: "darwin-bundle",
 	templateFiles: map[string]string{
 		"darwin-bundle/Info.plist.tmpl": "{{.applicationName}} {{.version}}.app/Contents/Info.plist.tmpl",
 	},
-	executableFiles:               []string{},
-	buildOutputDirectory:          "{{.applicationName}} {{.version}}.app/Contents/MacOS",
-	packagingScriptTemplate:       "mkdir -p \"{{.applicationName}} {{.version}}.app/Contents/Resources\" && png2icns \"{{.applicationName}} {{.version}}.app/Contents/Resources/icon.icns\" \"{{.applicationName}} {{.version}}.app/Contents/MacOS/assets/icon.png\"",
-	outputFileExtension:           "app",
-	outputFileContainsVersion:     true,
-	outputFileUsesApplicationName: true,
+	executableFiles:             []string{},
+	flutterBuildOutputDirectory: "{{.applicationName}} {{.version}}.app/Contents/MacOS",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		outputFileName := fmt.Sprintf("%s %s.app", applicationName, version)
+		err := os.MkdirAll(filepath.Join(tmpPath, outputFileName, "Contents", "Resources"), 0755)
+		if err != nil {
+			return "", err
+		}
+		cmdPng2icns := exec.Command("png2icns", filepath.Join(outputFileName, "Contents", "Resources", "icon.icns"), filepath.Join(outputFileName, "Contents", "MacOS", "assets", "icon.png"))
+		cmdPng2icns.Dir = tmpPath
+		cmdPng2icns.Stdout = os.Stdout
+		cmdPng2icns.Stderr = os.Stderr
+		err = cmdPng2icns.Run()
+		if err != nil {
+			return "", err
+		}
+		return outputFileName, nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"png2icns"},
+	},
 }

--- a/cmd/packaging/darwin-bundle.go
+++ b/cmd/packaging/darwin-bundle.go
@@ -15,7 +15,7 @@ var DarwinBundleTask = &packagingTask{
 	},
 	executableFiles:             []string{},
 	flutterBuildOutputDirectory: "{{.applicationName}} {{.version}}.app/Contents/MacOS",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		outputFileName := fmt.Sprintf("%s %s.app", applicationName, version)
 		err := os.MkdirAll(filepath.Join(tmpPath, outputFileName, "Contents", "Resources"), 0755)
 		if err != nil {

--- a/cmd/packaging/darwin-dmg.go
+++ b/cmd/packaging/darwin-dmg.go
@@ -1,14 +1,39 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // DarwinDmgTask packaging for darwin as dmg
 var DarwinDmgTask = &packagingTask{
 	packagingFormatName: "darwin-dmg",
 	dependsOn: map[*packagingTask]string{
 		DarwinBundleTask: "dmgdir",
 	},
-	packagingScriptTemplate:       "ln -sf /Applications dmgdir/Applications && genisoimage -V {{.packageName}} -D -R -apple -no-pad -o \"{{.applicationName}} {{.version}}.dmg\" dmgdir",
-	outputFileExtension:           "dmg",
-	outputFileContainsVersion:     true,
-	outputFileUsesApplicationName: true,
-	skipAssertInitialized:         true,
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		outputFileName := fmt.Sprintf("%s %s.dmg", applicationName, version)
+		cmdLn := exec.Command("ln", "-sf", "/Applications", "dmgdir/Applications")
+		cmdLn.Dir = tmpPath
+		cmdLn.Stdout = os.Stdout
+		cmdLn.Stderr = os.Stderr
+		err := cmdLn.Run()
+		if err != nil {
+			return "", err
+		}
+		cmdGenisoimage := exec.Command("genisoimage", "-V", packageName, "-D", "-R", "-apple", "-no-pad", "-o", outputFileName, "dmgdir")
+		cmdGenisoimage.Dir = tmpPath
+		cmdGenisoimage.Stdout = os.Stdout
+		cmdGenisoimage.Stderr = os.Stderr
+		err = cmdGenisoimage.Run()
+		if err != nil {
+			return "", err
+		}
+		return outputFileName, nil
+	},
+	skipAssertInitialized: true,
+	requiredTools: map[string][]string{
+		"linux": {"ln", "genisoimage"},
+	},
 }

--- a/cmd/packaging/darwin-dmg.go
+++ b/cmd/packaging/darwin-dmg.go
@@ -12,7 +12,7 @@ var DarwinDmgTask = &packagingTask{
 	dependsOn: map[*packagingTask]string{
 		DarwinBundleTask: "dmgdir",
 	},
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		outputFileName := fmt.Sprintf("%s %s.dmg", applicationName, version)
 		cmdLn := exec.Command("ln", "-sf", "/Applications", "dmgdir/Applications")
 		cmdLn.Dir = tmpPath

--- a/cmd/packaging/darwin-pkg.go
+++ b/cmd/packaging/darwin-pkg.go
@@ -1,5 +1,12 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
 // DarwinPkgTask packaging for darwin as pkg
 var DarwinPkgTask = &packagingTask{
 	packagingFormatName: "darwin-pkg",
@@ -10,8 +17,85 @@ var DarwinPkgTask = &packagingTask{
 		"darwin-pkg/PackageInfo.tmpl":  "flat/base.pkg/PackageInfo.tmpl",
 		"darwin-pkg/Distribution.tmpl": "flat/Distribution.tmpl",
 	},
-	packagingScriptTemplate:       "(cd flat/root && find . | cpio -o --format odc --owner 0:80 | gzip -c ) > flat/base.pkg/Payload && mkbom -u 0 -g 80 flat/root flat/base.pkg/Bom && (cd flat && xar --compression none -cf \"../{{.applicationName}} {{.version}}.pkg\" * )",
-	outputFileExtension:           "pkg",
-	outputFileContainsVersion:     true,
-	outputFileUsesApplicationName: true,
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		outputFileName := fmt.Sprintf("%s %s.pkg", applicationName, version)
+
+		payload, err := os.OpenFile(filepath.Join("flat", "base.pkg", "Payload"), os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			return "", nil
+		}
+
+		cmdFind := exec.Command("find", ".")
+		cmdFind.Dir = filepath.Join(tmpPath, "flat", "root")
+		cmdCpio := exec.Command("cpio", "-o", "--format", "odc", "--owner", "0:80")
+		cmdCpio.Dir = filepath.Join(tmpPath, "flat", "root")
+		cmdGzip := exec.Command("gzip", "-c")
+
+		// Pipes like this: find | cpio | gzip > Payload
+		cmdCpio.Stdin, err = cmdFind.StderrPipe()
+		if err != nil {
+			return "", nil
+		}
+		cmdGzip.Stdin, err = cmdCpio.StderrPipe()
+		if err != nil {
+			return "", nil
+		}
+		cmdGzip.Stdout = payload
+
+		err = cmdGzip.Start()
+		if err != nil {
+			return "", nil
+		}
+		err = cmdCpio.Start()
+		if err != nil {
+			return "", nil
+		}
+		err = cmdFind.Run()
+		if err != nil {
+			return "", nil
+		}
+		err = cmdCpio.Wait()
+		if err != nil {
+			return "", nil
+		}
+		err = cmdGzip.Wait()
+		if err != nil {
+			return "", nil
+		}
+		err = payload.Close()
+		if err != nil {
+			return "", nil
+		}
+
+		cmdMkbom := exec.Command("mkbom", "-u", "0", "-g", "80", filepath.Join("flat", "root"), filepath.Join("flat", "base.pkg", "Payload"))
+		cmdMkbom.Dir = tmpPath
+		cmdMkbom.Stdout = os.Stdout
+		cmdMkbom.Stderr = os.Stderr
+		err = cmdMkbom.Run()
+		if err != nil {
+			return "", nil
+		}
+
+		var files []string
+		err = filepath.Walk(tmpPath, func(path string, info os.FileInfo, err error) error {
+			files = append(files, path)
+			return nil
+		})
+		if err != nil {
+			return "", nil
+		}
+
+		cmdXar := exec.Command("xar", append([]string{"--compression", "none", "-cf", filepath.Join("..", outputFileName)}, files...)...)
+		cmdXar.Dir = filepath.Join(tmpPath, "flat")
+		cmdXar.Stdout = os.Stdout
+		cmdXar.Stderr = os.Stderr
+		err = cmdXar.Run()
+		if err != nil {
+			return "", nil
+		}
+		return outputFileName, nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"find", "cpio", "gzip", "mkbom", "xar"},
+	},
 }

--- a/cmd/packaging/darwin-pkg.go
+++ b/cmd/packaging/darwin-pkg.go
@@ -17,7 +17,7 @@ var DarwinPkgTask = &packagingTask{
 		"darwin-pkg/PackageInfo.tmpl":  "flat/base.pkg/PackageInfo.tmpl",
 		"darwin-pkg/Distribution.tmpl": "flat/Distribution.tmpl",
 	},
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		outputFileName := fmt.Sprintf("%s %s.pkg", applicationName, version)
 
 		payload, err := os.OpenFile(filepath.Join("flat", "base.pkg", "Payload"), os.O_RDWR|os.O_CREATE, 0755)

--- a/cmd/packaging/linux-appimage.go
+++ b/cmd/packaging/linux-appimage.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+
+	copy "github.com/otiai10/copy"
+
+	"github.com/go-flutter-desktop/hover/internal/log"
 )
 
 // LinuxAppImageTask packaging for linux as AppImage
@@ -11,24 +16,49 @@ var LinuxAppImageTask = &packagingTask{
 	packagingFormatName: "linux-appimage",
 	templateFiles: map[string]string{
 		"linux-appimage/AppRun.tmpl": "AppRun.tmpl",
-		"linux/app.desktop.tmpl":     "{{.executableName}}.desktop.tmpl",
+		"linux/app.desktop.tmpl":     "{{.strippedApplicationName}}.desktop.tmpl",
 	},
 	executableFiles: []string{
+		".",
 		"AppRun",
-		"{{.executableName}}.desktop",
+		"{{.strippedApplicationName}}.desktop",
 	},
-	linuxDesktopFileIconPath:    "/build/assets/icon",
+	linuxDesktopFileIconPath:    "{{.strippedApplicationName}}",
 	flutterBuildOutputDirectory: "build",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
+		sourceIconPath := filepath.Join(tmpPath, "build", "assets", "icon.png")
+		iconDir := filepath.Join(tmpPath, "usr", "share", "icons", "hicolor", "256x256", "apps")
+		if _, err := os.Stat(iconDir); os.IsNotExist(err) {
+			err = os.MkdirAll(iconDir, 0755)
+			if err != nil {
+				log.Errorf("Failed to create icon dir: %v", err)
+				os.Exit(1)
+			}
+		}
+		err := copy.Copy(sourceIconPath, filepath.Join(tmpPath, fmt.Sprintf("%s.png", strippedApplicationName)))
+		if err != nil {
+			log.Errorf("Failed to copy icon root dir: %v", err)
+			os.Exit(1)
+		}
+		err = copy.Copy(sourceIconPath, filepath.Join(iconDir, fmt.Sprintf("%s.png", strippedApplicationName)))
+		if err != nil {
+			log.Errorf("Failed to copy icon dir: %v", err)
+			os.Exit(1)
+		}
 		cmdAppImageTool := exec.Command("appimagetool", ".")
 		cmdAppImageTool.Dir = tmpPath
 		cmdAppImageTool.Stdout = os.Stdout
 		cmdAppImageTool.Stderr = os.Stderr
-		err := cmdAppImageTool.Run()
+		cmdAppImageTool.Env = append(
+			os.Environ(),
+			"ARCH=x86_64",
+			fmt.Sprintf("VERSION=%s", version),
+		)
+		err = cmdAppImageTool.Run()
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("%s-x86_64.AppImage", executableName), nil
+		return fmt.Sprintf("%s-%s-x86_64.AppImage", strippedApplicationName, version), nil
 	},
 	requiredTools: map[string][]string{
 		"linux": {"appimagetool"},

--- a/cmd/packaging/linux-appimage.go
+++ b/cmd/packaging/linux-appimage.go
@@ -1,5 +1,11 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // LinuxAppImageTask packaging for linux as AppImage
 var LinuxAppImageTask = &packagingTask{
 	packagingFormatName: "linux-appimage",
@@ -11,10 +17,20 @@ var LinuxAppImageTask = &packagingTask{
 		"AppRun",
 		"{{.executableName}}.desktop",
 	},
-	linuxDesktopFileIconPath:      "/build/assets/icon",
-	buildOutputDirectory:          "build",
-	packagingScriptTemplate:       "appimagetool . && mv -n {{.executableName}}-x86_64.AppImage {{.packageName}}-{{.version}}.AppImage",
-	outputFileExtension:           "AppImage",
-	outputFileContainsVersion:     true,
-	outputFileUsesApplicationName: false,
+	linuxDesktopFileIconPath:    "/build/assets/icon",
+	flutterBuildOutputDirectory: "build",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		cmdAppImageTool := exec.Command("appimagetool", ".")
+		cmdAppImageTool.Dir = tmpPath
+		cmdAppImageTool.Stdout = os.Stdout
+		cmdAppImageTool.Stderr = os.Stderr
+		err := cmdAppImageTool.Run()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s-x86_64.AppImage", executableName), nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"appimagetool"},
+	},
 }

--- a/cmd/packaging/linux-deb.go
+++ b/cmd/packaging/linux-deb.go
@@ -1,5 +1,11 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // LinuxDebTask packaging for linux as deb
 var LinuxDebTask = &packagingTask{
 	packagingFormatName: "linux-deb",
@@ -14,9 +20,20 @@ var LinuxDebTask = &packagingTask{
 	},
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
-	buildOutputDirectory:           "usr/lib/{{.packageName}}",
-	packagingScriptTemplate:        "dpkg-deb --build . {{.packageName}}-{{.version}}.deb",
-	outputFileExtension:            "deb",
-	outputFileContainsVersion:      true,
-	outputFileUsesApplicationName:  false,
+	flutterBuildOutputDirectory:    "usr/lib/{{.packageName}}",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		outputFileName := fmt.Sprintf("%s_%s_amd64.deb", packageName, version)
+		cmdDpkgDeb := exec.Command("dpkg-deb", "--build", ".", outputFileName)
+		cmdDpkgDeb.Dir = tmpPath
+		cmdDpkgDeb.Stdout = os.Stdout
+		cmdDpkgDeb.Stderr = os.Stderr
+		err := cmdDpkgDeb.Run()
+		if err != nil {
+			return "", err
+		}
+		return outputFileName, nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"dpkg-deb"},
+	},
 }

--- a/cmd/packaging/linux-deb.go
+++ b/cmd/packaging/linux-deb.go
@@ -21,7 +21,7 @@ var LinuxDebTask = &packagingTask{
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
 	flutterBuildOutputDirectory:    "usr/lib/{{.packageName}}",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		outputFileName := fmt.Sprintf("%s_%s_amd64.deb", packageName, version)
 		cmdDpkgDeb := exec.Command("dpkg-deb", "--build", ".", outputFileName)
 		cmdDpkgDeb.Dir = tmpPath

--- a/cmd/packaging/linux-pkg.go
+++ b/cmd/packaging/linux-pkg.go
@@ -21,7 +21,7 @@ var LinuxPkgTask = &packagingTask{
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
 	flutterBuildOutputDirectory:    "src/usr/lib/{{.packageName}}",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		cmdMakepkg := exec.Command("makepkg")
 		cmdMakepkg.Dir = tmpPath
 		cmdMakepkg.Stdout = os.Stdout

--- a/cmd/packaging/linux-pkg.go
+++ b/cmd/packaging/linux-pkg.go
@@ -1,5 +1,11 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // LinuxPkgTask packaging for linux as pacman pkg
 var LinuxPkgTask = &packagingTask{
 	packagingFormatName: "linux-pkg",
@@ -14,9 +20,19 @@ var LinuxPkgTask = &packagingTask{
 	},
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
-	buildOutputDirectory:           "src/usr/lib/{{.packageName}}",
-	packagingScriptTemplate:        "makepkg && mv -n {{.packageName}}-{{.version}}-{{.release}}-x86_64.pkg.tar.xz {{.packageName}}-{{.version}}.pkg.tar.xz",
-	outputFileExtension:            "pkg.tar.xz",
-	outputFileContainsVersion:      true,
-	outputFileUsesApplicationName:  false,
+	flutterBuildOutputDirectory:    "src/usr/lib/{{.packageName}}",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		cmdMakepkg := exec.Command("makepkg")
+		cmdMakepkg.Dir = tmpPath
+		cmdMakepkg.Stdout = os.Stdout
+		cmdMakepkg.Stderr = os.Stderr
+		err := cmdMakepkg.Run()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s-%s-%s-x86_64.pkg.tar.xz", packageName, version, release), nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"makepkg"},
+	},
 }

--- a/cmd/packaging/linux-rpm.go
+++ b/cmd/packaging/linux-rpm.go
@@ -21,7 +21,7 @@ var LinuxRpmTask = &packagingTask{
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
 	flutterBuildOutputDirectory:    "BUILD/{{.packageName}}-{{.version}}-{{.release}}.x86_64/usr/lib/{{.packageName}}",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		cmdRpmbuild := exec.Command("rpmbuild", "--define", fmt.Sprintf("_topdir %s", tmpPath), "--define", "_unpackaged_files_terminate_build 0", "-ba", fmt.Sprintf("./SPECS/%s.spec", packageName))
 		cmdRpmbuild.Dir = tmpPath
 		cmdRpmbuild.Stdout = os.Stdout

--- a/cmd/packaging/linux-rpm.go
+++ b/cmd/packaging/linux-rpm.go
@@ -1,5 +1,11 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // LinuxRpmTask packaging for linux as rpm
 var LinuxRpmTask = &packagingTask{
 	packagingFormatName: "linux-rpm",
@@ -14,9 +20,19 @@ var LinuxRpmTask = &packagingTask{
 	},
 	linuxDesktopFileExecutablePath: "/usr/lib/{{.packageName}}/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/usr/lib/{{.packageName}}/assets/icon.png",
-	buildOutputDirectory:           "BUILD/{{.packageName}}-{{.version}}-{{.release}}.x86_64/usr/lib/{{.packageName}}",
-	packagingScriptTemplate:        "rpmbuild --define \"_topdir $(pwd)\" --define \"_unpackaged_files_terminate_build 0\" -ba ./SPECS/{{.packageName}}.spec && mv -n RPMS/x86_64/{{.packageName}}-{{.version}}-{{.release}}.x86_64.rpm {{.packageName}}-{{.version}}.rpm",
-	outputFileExtension:            "rpm",
-	outputFileContainsVersion:      true,
-	outputFileUsesApplicationName:  false,
+	flutterBuildOutputDirectory:    "BUILD/{{.packageName}}-{{.version}}-{{.release}}.x86_64/usr/lib/{{.packageName}}",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		cmdRpmbuild := exec.Command("rpmbuild", "--define", fmt.Sprintf("_topdir %s", tmpPath), "--define", "_unpackaged_files_terminate_build 0", "-ba", fmt.Sprintf("./SPECS/%s.spec", packageName))
+		cmdRpmbuild.Dir = tmpPath
+		cmdRpmbuild.Stdout = os.Stdout
+		cmdRpmbuild.Stderr = os.Stderr
+		err := cmdRpmbuild.Run()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("RPMS/x86_64/%s-%s-%s.x86_64.rpm", packageName, version, release), nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"rpmbuild"},
+	},
 }

--- a/cmd/packaging/linux-snap.go
+++ b/cmd/packaging/linux-snap.go
@@ -16,7 +16,7 @@ var LinuxSnapTask = &packagingTask{
 	linuxDesktopFileExecutablePath: "/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/icon.png",
 	flutterBuildOutputDirectory:    "build",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		cmdSnapcraft := exec.Command("snapcraft")
 		cmdSnapcraft.Dir = tmpPath
 		cmdSnapcraft.Stdout = os.Stdout

--- a/cmd/packaging/linux-snap.go
+++ b/cmd/packaging/linux-snap.go
@@ -1,5 +1,11 @@
 package packaging
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // LinuxSnapTask packaging for linux as snap
 var LinuxSnapTask = &packagingTask{
 	packagingFormatName: "linux-snap",
@@ -9,9 +15,19 @@ var LinuxSnapTask = &packagingTask{
 	},
 	linuxDesktopFileExecutablePath: "/{{.executableName}}",
 	linuxDesktopFileIconPath:       "/icon.png",
-	buildOutputDirectory:           "build",
-	packagingScriptTemplate:        "snapcraft && mv -n {{.packageName}}_{{.version}}_{{.arch}}.snap {{.packageName}}-{{.version}}.snap",
-	outputFileExtension:            "snap",
-	outputFileContainsVersion:      true,
-	outputFileUsesApplicationName:  false,
+	flutterBuildOutputDirectory:    "build",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		cmdSnapcraft := exec.Command("snapcraft")
+		cmdSnapcraft.Dir = tmpPath
+		cmdSnapcraft.Stdout = os.Stdout
+		cmdSnapcraft.Stderr = os.Stderr
+		err := cmdSnapcraft.Run()
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s_%s_amd64.snap", packageName, version), nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"snapcraft"},
+	},
 }

--- a/cmd/packaging/noop.go
+++ b/cmd/packaging/noop.go
@@ -4,8 +4,9 @@ type noopTask struct{}
 
 var NoopTask Task = &noopTask{}
 
-func (_ *noopTask) Name() string             { return "" }
-func (_ *noopTask) Init()                    {}
-func (_ *noopTask) IsInitialized() bool      { return true }
-func (_ *noopTask) AssertInitialized()       {}
-func (_ *noopTask) Pack(buildVersion string) {}
+func (_ *noopTask) Name() string        { return "" }
+func (_ *noopTask) Init()               {}
+func (_ *noopTask) IsInitialized() bool { return true }
+func (_ *noopTask) AssertInitialized()  {}
+func (_ *noopTask) Pack(string)         {}
+func (_ *noopTask) AssertSupported()    {}

--- a/cmd/packaging/packaging.go
+++ b/cmd/packaging/packaging.go
@@ -54,20 +54,39 @@ func getTemporaryBuildDirectory(projectName string, packagingFormat string) stri
 	return tmpPath
 }
 
-func runPackaging(path string, command string) {
-	bashCmd := exec.Command("bash", "-c", command)
-	bashCmd.Stderr = os.Stderr
-	bashCmd.Stdout = os.Stdout
-	bashCmd.Dir = path
-	err := bashCmd.Run()
-	if err != nil {
-		log.Warnf("Packaging is very experimental and has only been tested on Linux.")
-		log.Infof("To help us debuging this error, please zip the content of:\n       \"%s\"\n       %s",
-			log.Au().Blue(path),
-			log.Au().Green("and try to package on another OS. You can also share this zip with the go-flutter team."))
-		log.Infof("You can package the app without hover by running:")
-		log.Infof("  `%s`", log.Au().Magenta("cd "+path))
-		log.Infof("  executed command: `%s`", log.Au().Magenta(bashCmd.String()))
+type packagingTask struct {
+	packagingFormatName            string                                                                                               // Name of the packaging format: OS-TYPE
+	dependsOn                      map[*packagingTask]string                                                                            // Packaging tasks this task depends on
+	templateFiles                  map[string]string                                                                                    // Template files to copy over on init
+	executableFiles                []string                                                                                             // Files that should be executable
+	linuxDesktopFileExecutablePath string                                                                                               // Path of the executable for linux .desktop file (only set on linux)
+	linuxDesktopFileIconPath       string                                                                                               // Path of the icon for linux .desktop file (only set on linux)
+	generateBuildFiles             func(packageName, path string)                                                                       // Generate dynamic build files. Operates in the temporary directory
+	flutterBuildOutputDirectory    string                                                                                               // Path to copy the build output of the app to. Operates in the temporary directory
+	packagingFunction              func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) // Function that actually packages the app. Needs to check for OS specific tools etc. . Returns the path of the packaged file
+	skipAssertInitialized          bool                                                                                                 // Set to true when a task doesn't need to be initialized.
+	requiredTools                  map[string][]string                                                                                  // Map of list of tools required to package per OS
+}
+
+func (t *packagingTask) AssertSupported() {
+	for task := range t.dependsOn {
+		task.AssertSupported()
+	}
+	if _, osIsSupported := t.requiredTools[runtime.GOOS]; !osIsSupported {
+		log.Errorf("Packaging %s is not supported on %s", t.packagingFormatName, runtime.GOOS)
+		log.Errorf("To still package %s on %s you need to run hover with the `--docker` flag.", t.packagingFormatName, runtime.GOOS)
+		os.Exit(1)
+	}
+	var unavailableTools []string
+	for _, tool := range t.requiredTools[runtime.GOOS] {
+		_, err := exec.LookPath(tool)
+		if err != nil {
+			unavailableTools = append(unavailableTools, tool)
+		}
+	}
+	if len(unavailableTools) > 0 {
+		log.Errorf("To package %s these tools are required: %s", t.packagingFormatName, strings.Join(unavailableTools, ","))
+		log.Errorf("To still package %s without the required tools installed you need to run hover with the `--docker` flag.", t.packagingFormatName)
 		os.Exit(1)
 	}
 }
@@ -75,47 +94,45 @@ func runPackaging(path string, command string) {
 var templateData map[string]string
 var once sync.Once
 
-func (t *packagingTask) getTemplateData(projectName, buildVersion string) map[string]string {
+var (
+	projectName      string
+	release          string
+	description      string
+	organizationName string
+	author           string
+	applicationName  string
+	executableName   string
+	packageName      string
+	license          string
+)
+
+func (t *packagingTask) initData(version string) map[string]string {
 	once.Do(func() {
+		projectName = pubspec.GetPubSpec().Name
+		release = strings.Split(version, "+")[1]
+		description = pubspec.GetPubSpec().Description
+		organizationName = androidmanifest.AndroidOrganizationName()
+		author = pubspec.GetPubSpec().GetAuthor()
+		applicationName = config.GetConfig().GetApplicationName(projectName)
+		executableName = config.GetConfig().GetExecutableName(projectName)
+		packageName = config.GetConfig().GetPackageName(projectName)
+		license = config.GetConfig().GetLicense()
 		templateData = map[string]string{
 			"projectName":      projectName,
-			"version":          buildVersion,
-			"release":          strings.Split(buildVersion, ".")[0],
-			"arch":             runtime.GOARCH,
-			"description":      pubspec.GetPubSpec().GetDescription(),
-			"organizationName": androidmanifest.AndroidOrganizationName(),
-			"author":           pubspec.GetPubSpec().GetAuthor(),
-			"applicationName":  config.GetConfig().GetApplicationName(projectName),
-			"executableName":   config.GetConfig().GetExecutableName(projectName),
-			"packageName":      config.GetConfig().GetPackageName(projectName),
-			"license":          config.GetConfig().GetLicense(),
+			"version":          version,
+			"release":          release,
+			"description":      description,
+			"organizationName": organizationName,
+			"author":           author,
+			"applicationName":  applicationName,
+			"executableName":   executableName,
+			"packageName":      packageName,
+			"license":          license,
 		}
 		templateData["iconPath"] = executeStringTemplate(t.linuxDesktopFileIconPath, templateData)
 		templateData["executablePath"] = executeStringTemplate(t.linuxDesktopFileExecutablePath, templateData)
 	})
 	return templateData
-}
-
-type packagingTask struct {
-	packagingFormatName            string                         // Name of the packaging format: OS-TYPE
-	dependsOn                      map[*packagingTask]string      // Packaging tasks this task depends on
-	templateFiles                  map[string]string              // Template files to copy over on init
-	executableFiles                []string                       // Files that should be executable
-	linuxDesktopFileExecutablePath string                         // Path of the executable for linux .desktop file (only set on linux)
-	linuxDesktopFileIconPath       string                         // Path of the icon for linux .desktop file (only set on linux)
-	generateBuildFiles             func(packageName, path string) // Generate dynamic build files. Operates in the temporary directory
-	buildOutputDirectory           string                         // Path to copy the build output of the app to. Operates in the temporary directory
-	packagingScriptTemplate        string                         // Template for the command that actually packages the app
-	outputFileExtension            string                         // File extension of the packaged app
-	// NOTE: outputFileContainsVersion is currently always true, we could
-	// consider adding a flag for it to let users disable it.
-	outputFileContainsVersion bool // Whether the output file name contains the version
-	// NOTE: outputFileUsesApplicationName is always true for darwin-* and
-	// windows-*, and always false for linux-*. We could consider adding a flag
-	// for it to enable and disable at will (defaulting to how it's currently
-	// configured).
-	outputFileUsesApplicationName bool // Uses the application name instead of the package name
-	skipAssertInitialized         bool // Set to true when a task doesn't need to be initialized.
 }
 
 func (t *packagingTask) Name() string {
@@ -150,11 +167,11 @@ func (t *packagingTask) init(ignoreAlreadyExists bool) {
 	}
 }
 
-func (t *packagingTask) Pack(buildVersion string) {
+func (t *packagingTask) Pack(version string) {
+	t.initData(version)
 	for task := range t.dependsOn {
-		task.Pack(buildVersion)
+		task.Pack(version)
 	}
-	projectName := pubspec.GetPubSpec().Name
 	tmpPath := getTemporaryBuildDirectory(projectName, t.packagingFormatName)
 	defer func() {
 		err := os.RemoveAll(tmpPath)
@@ -165,8 +182,8 @@ func (t *packagingTask) Pack(buildVersion string) {
 	}()
 	log.Infof("Packaging %s in %s", strings.Split(t.packagingFormatName, "-")[1], tmpPath)
 
-	if t.buildOutputDirectory != "" {
-		err := copy.Copy(build.OutputDirectoryPath(strings.Split(t.packagingFormatName, "-")[0]), executeStringTemplate(filepath.Join(tmpPath, t.buildOutputDirectory), t.getTemplateData(projectName, buildVersion)))
+	if t.flutterBuildOutputDirectory != "" {
+		err := copy.Copy(build.OutputDirectoryPath(strings.Split(t.packagingFormatName, "-")[0]), executeStringTemplate(filepath.Join(tmpPath, t.flutterBuildOutputDirectory), templateData))
 		if err != nil {
 			log.Errorf("Could not copy build folder: %v", err)
 			os.Exit(1)
@@ -179,14 +196,14 @@ func (t *packagingTask) Pack(buildVersion string) {
 			os.Exit(1)
 		}
 	}
-	fileutils.CopyTemplateDir(packagingFormatPath(t.packagingFormatName), filepath.Join(tmpPath), t.getTemplateData(projectName, buildVersion))
+	fileutils.CopyTemplateDir(packagingFormatPath(t.packagingFormatName), filepath.Join(tmpPath), templateData)
 	if t.generateBuildFiles != nil {
 		log.Infof("Generating dynamic build files")
 		t.generateBuildFiles(config.GetConfig().GetPackageName(projectName), tmpPath)
 	}
 
 	for _, file := range t.executableFiles {
-		err := os.Chmod(executeStringTemplate(filepath.Join(tmpPath, file), t.getTemplateData(projectName, buildVersion)), 0777)
+		err := os.Chmod(executeStringTemplate(filepath.Join(tmpPath, file), templateData), 0777)
 		if err != nil {
 			log.Errorf("Failed to change file permissions for %s file: %v", file, err)
 			os.Exit(1)
@@ -200,25 +217,18 @@ func (t *packagingTask) Pack(buildVersion string) {
 		os.Exit(1)
 	}
 
-	packagingScript := executeStringTemplate(t.packagingScriptTemplate, t.getTemplateData(projectName, buildVersion))
-	runPackaging(tmpPath, packagingScript)
-	var outputFileName string
-	if t.outputFileUsesApplicationName {
-		outputFileName += config.GetConfig().GetApplicationName(projectName)
-	} else {
-		outputFileName += config.GetConfig().GetPackageName(projectName)
+	relativeOutputFilePath, err := t.packagingFunction(tmpPath, applicationName, packageName, executableName, version, release)
+	if err != nil {
+		log.Errorf("%v", err)
+		log.Warnf("Packaging is very experimental and has only been tested on Linux.")
+		log.Infof("To help us debuging this error, please zip the content of:\n       \"%s\"\n       %s",
+			log.Au().Blue(tmpPath),
+			log.Au().Green("and try to package on another OS. You can also share this zip with the go-flutter team."))
+		os.Exit(1)
 	}
-	if t.outputFileContainsVersion {
-		if t.outputFileUsesApplicationName {
-			outputFileName += " "
-		} else {
-			outputFileName += "-"
-		}
-		outputFileName += buildVersion
-	}
-	outputFileName += "." + t.outputFileExtension
-	outputFilePath := executeStringTemplate(filepath.Join(build.OutputDirectoryPath(t.packagingFormatName), outputFileName), t.getTemplateData(projectName, buildVersion))
-	err = copy.Copy(filepath.Join(tmpPath, outputFileName), outputFilePath)
+	outputFileName := filepath.Base(relativeOutputFilePath)
+	outputFilePath := filepath.Join(build.OutputDirectoryPath(t.packagingFormatName), outputFileName)
+	err = copy.Copy(filepath.Join(tmpPath, relativeOutputFilePath), outputFilePath)
 	if err != nil {
 		log.Errorf("Could not move %s file: %v", outputFileName, err)
 		os.Exit(1)

--- a/cmd/packaging/packaging.go
+++ b/cmd/packaging/packaging.go
@@ -223,10 +223,10 @@ func (t *packagingTask) Pack(version string) {
 	relativeOutputFilePath, err := t.packagingFunction(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release)
 	if err != nil {
 		log.Errorf("%v", err)
-		log.Warnf("Packaging is very experimental and has only been tested on Linux.")
-		log.Infof("To help us debuging this error, please zip the content of:\n       \"%s\"\n       %s",
-			log.Au().Blue(tmpPath),
-			log.Au().Green("and try to package on another OS. You can also share this zip with the go-flutter team."))
+		log.Warnf("Packaging is very experimental and has mostly been tested on Linux.")
+		log.Infof("Please open an issue at https://github.com/go-flutter-desktop/go-flutter/issues/new?template=BUG.md")
+		log.Infof("with the log and a reproducible example if possible. You may also zip your app code")
+		log.Infof("if you are comfortable with it (closed source etc.) and attach it to the issue.")
 		os.Exit(1)
 	}
 	outputFileName := filepath.Base(relativeOutputFilePath)

--- a/cmd/packaging/task.go
+++ b/cmd/packaging/task.go
@@ -8,4 +8,5 @@ type Task interface {
 	IsInitialized() bool
 	AssertInitialized()
 	Pack(buildVersion string)
+	AssertSupported()
 }

--- a/cmd/packaging/windows-msi.go
+++ b/cmd/packaging/windows-msi.go
@@ -22,7 +22,7 @@ var WindowsMsiTask = &packagingTask{
 		"windows-msi/app.wxs.tmpl": "{{.packageName}}.wxs.tmpl",
 	},
 	flutterBuildOutputDirectory: "build",
-	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+	packagingFunction: func(tmpPath, applicationName, strippedApplicationName, packageName, executableName, version, release string) (string, error) {
 		outputFileName := fmt.Sprintf("%s %s.msi", applicationName, version)
 		cmdConvert := exec.Command("convert", "-resize", "x16", "build/assets/icon.png", "build/assets/icon.ico")
 		cmdConvert.Dir = tmpPath

--- a/cmd/packaging/windows-msi.go
+++ b/cmd/packaging/windows-msi.go
@@ -1,8 +1,10 @@
 package packaging
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -19,11 +21,30 @@ var WindowsMsiTask = &packagingTask{
 	templateFiles: map[string]string{
 		"windows-msi/app.wxs.tmpl": "{{.packageName}}.wxs.tmpl",
 	},
-	buildOutputDirectory:          "build",
-	packagingScriptTemplate:       "convert -resize x16 build/assets/icon.png build/assets/icon.ico && wixl -v {{.packageName}}.wxs && mv -n {{.packageName}}.msi \"{{.applicationName}} {{.version}}.msi\"",
-	outputFileExtension:           "msi",
-	outputFileContainsVersion:     true,
-	outputFileUsesApplicationName: true,
+	flutterBuildOutputDirectory: "build",
+	packagingFunction: func(tmpPath, applicationName, packageName, executableName, version, release string) (string, error) {
+		outputFileName := fmt.Sprintf("%s %s.msi", applicationName, version)
+		cmdConvert := exec.Command("convert", "-resize", "x16", "build/assets/icon.png", "build/assets/icon.ico")
+		cmdConvert.Dir = tmpPath
+		cmdConvert.Stdout = os.Stdout
+		cmdConvert.Stderr = os.Stderr
+		err := cmdConvert.Run()
+		if err != nil {
+			return "", err
+		}
+		cmdWixl := exec.Command("wixl", "-v", fmt.Sprintf("%s.wxs", packageName), "-o", outputFileName)
+		cmdWixl.Dir = tmpPath
+		cmdWixl.Stdout = os.Stdout
+		cmdWixl.Stderr = os.Stderr
+		err = cmdWixl.Run()
+		if err != nil {
+			return "", err
+		}
+		return outputFileName, nil
+	},
+	requiredTools: map[string][]string{
+		"linux": {"convert", "wixl"},
+	},
 	generateBuildFiles: func(packageName, tmpPath string) {
 		directoriesFilePath, err := filepath.Abs(filepath.Join(tmpPath, "directories.wxi"))
 		if err != nil {


### PR DESCRIPTION
Adds automatic tool detection for each platform (currently only linux). If a tool is not present or the packaging format cannot be build on a platform the build switches to docker automatically.
This PR also splits the packaging scripts for each platform. This is later needed as the scripts will differ for each platform (basic logic for https://github.com/go-flutter-desktop/go-flutter/issues/395).