### PR TITLE
Fix config/pubspec reading

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -223,7 +223,7 @@ func initBuildParameters(targetOS string) {
 	}
 
 	if buildVersionNumber == "" {
-		buildVersionNumber = pubspec.GetPubSpec().Version
+		buildVersionNumber = pubspec.GetPubSpec().GetVersion()
 	}
 
 	if buildSkipEngineDownload {
@@ -414,7 +414,7 @@ func buildGoBinary(targetOS string, vmArguments []string) {
 		}
 	}
 
-	buildCommandString := buildCommand(targetOS, vmArguments, build.OutputBinaryPath(config.GetConfig().ExecutableName(pubspec.GetPubSpec().Name), targetOS))
+	buildCommandString := buildCommand(targetOS, vmArguments, build.OutputBinaryPath(config.GetConfig().GetExecutableName(pubspec.GetPubSpec().Name), targetOS))
 	cmdGoBuild := exec.Command(buildCommandString[0], buildCommandString[1:]...)
 	cmdGoBuild.Dir = filepath.Join(wd, build.BuildPath)
 	cmdGoBuild.Env = append(os.Environ(),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -70,9 +70,9 @@ var initCmd = &cobra.Command{
 		fileutils.CopyAsset("app/icon.png", filepath.Join(desktopAssetsPath, "icon.png"), fileutils.AssetsBox())
 		fileutils.CopyAsset("app/gitignore", filepath.Join(build.BuildPath, ".gitignore"), fileutils.AssetsBox())
 		fileutils.ExecuteTemplateFromAssetsBox("app/hover.yaml.tmpl", filepath.Join(build.BuildPath, "hover.yaml"), fileutils.AssetsBox(), map[string]string{
-			"applicationName": emptyConfig.ApplicationName(projectName),
-			"executableName":  emptyConfig.ExecutableName(projectName),
-			"packageName":     emptyConfig.PackageName(projectName),
+			"applicationName": emptyConfig.GetApplicationName(projectName),
+			"executableName":  emptyConfig.GetExecutableName(projectName),
+			"packageName":     emptyConfig.GetPackageName(projectName),
 		})
 
 		initializeGoModule(projectPath)

--- a/cmd/packaging/packaging.go
+++ b/cmd/packaging/packaging.go
@@ -82,13 +82,13 @@ func (t *packagingTask) getTemplateData(projectName, buildVersion string) map[st
 			"version":          buildVersion,
 			"release":          strings.Split(buildVersion, ".")[0],
 			"arch":             runtime.GOARCH,
-			"description":      pubspec.GetPubSpec().Description,
+			"description":      pubspec.GetPubSpec().GetDescription(),
 			"organizationName": androidmanifest.AndroidOrganizationName(),
-			"author":           config.GetConfig().Author(),
-			"applicationName":  config.GetConfig().ApplicationName(projectName),
-			"executableName":   config.GetConfig().ExecutableName(projectName),
-			"packageName":      config.GetConfig().PackageName(projectName),
-			"license":          config.GetConfig().License(),
+			"author":           pubspec.GetPubSpec().GetAuthor(),
+			"applicationName":  config.GetConfig().GetApplicationName(projectName),
+			"executableName":   config.GetConfig().GetExecutableName(projectName),
+			"packageName":      config.GetConfig().GetPackageName(projectName),
+			"license":          config.GetConfig().GetLicense(),
 		}
 		templateData["iconPath"] = executeStringTemplate(t.linuxDesktopFileIconPath, templateData)
 		templateData["executablePath"] = executeStringTemplate(t.linuxDesktopFileExecutablePath, templateData)
@@ -182,7 +182,7 @@ func (t *packagingTask) Pack(buildVersion string) {
 	fileutils.CopyTemplateDir(packagingFormatPath(t.packagingFormatName), filepath.Join(tmpPath), t.getTemplateData(projectName, buildVersion))
 	if t.generateBuildFiles != nil {
 		log.Infof("Generating dynamic build files")
-		t.generateBuildFiles(config.GetConfig().PackageName(projectName), tmpPath)
+		t.generateBuildFiles(config.GetConfig().GetPackageName(projectName), tmpPath)
 	}
 
 	for _, file := range t.executableFiles {
@@ -204,9 +204,9 @@ func (t *packagingTask) Pack(buildVersion string) {
 	runPackaging(tmpPath, packagingScript)
 	var outputFileName string
 	if t.outputFileUsesApplicationName {
-		outputFileName += config.GetConfig().ApplicationName(projectName)
+		outputFileName += config.GetConfig().GetApplicationName(projectName)
 	} else {
-		outputFileName += config.GetConfig().PackageName(projectName)
+		outputFileName += config.GetConfig().GetPackageName(projectName)
 	}
 	if t.outputFileContainsVersion {
 		if t.outputFileUsesApplicationName {

--- a/cmd/publish-plugin.go
+++ b/cmd/publish-plugin.go
@@ -100,9 +100,9 @@ import (
 			match = []string{"", "origin"}
 		}
 
-		tag := "go/v" + pubspec.GetPubSpec().Version
+		tag := "go/v" + pubspec.GetPubSpec().GetVersion()
 
-		log.Infof("Your plugin at version '%s' is ready to be publish as a golang module.", pubspec.GetPubSpec().Version)
+		log.Infof("Your plugin at version '%s' is ready to be publish as a golang module.", pubspec.GetPubSpec().GetVersion())
 		log.Infof("Please run: `%s`", log.Au().Magenta("git tag "+tag))
 		log.Infof("            `%s`", log.Au().Magenta("git push "+match[1]+" "+tag))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/log"
-	"github.com/go-flutter-desktop/hover/internal/pubspec"
 )
 
 // BuildTargetDefault Default build target file
@@ -29,10 +27,10 @@ const BuildOpenGlVersionDefault = "3.3"
 // Config contains the parsed contents of hover.yaml
 type Config struct {
 	loaded          bool
-	applicationName string `yaml:"application-name"`
-	executableName  string `yaml:"executable-name"`
-	packageName     string `yaml:"package-name"`
-	license         string
+	ApplicationName string `yaml:"application-name"`
+	ExecutableName  string `yaml:"executable-name"`
+	PackageName     string `yaml:"package-name"`
+	License         string
 	Target          string
 	Branch          string
 	CachePath       string `yaml:"cache-path"`
@@ -40,51 +38,33 @@ type Config struct {
 	Engine          string `yaml:"engine-version"`
 }
 
-func (c Config) ApplicationName(projectName string) string {
-	if c.applicationName == "" {
+func (c Config) GetApplicationName(projectName string) string {
+	if c.ApplicationName == "" {
 		return projectName
 	}
-	return c.applicationName
+	return c.ApplicationName
 }
 
-func (c Config) ExecutableName(projectName string) string {
-	if c.executableName == "" {
+func (c Config) GetExecutableName(projectName string) string {
+	if c.ExecutableName == "" {
 		return strings.ReplaceAll(projectName, " ", "")
 	}
-	return c.executableName
+	return c.ExecutableName
 }
 
-func (c Config) PackageName(projectName string) string {
-	if c.packageName == "" {
+func (c Config) GetPackageName(projectName string) string {
+	if c.PackageName == "" {
 		return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(projectName, "-", ""), "_", ""), " ", "")
 	}
-	return c.packageName
+	return c.PackageName
 }
 
-func (c Config) License() string {
-	if c.license == "" {
-		log.Warnf("Missing/Empty `license` field in go/hover.yaml.")
-		log.Warnf("Please add it otherwise you may publish your app with a wrong license.")
-		log.Warnf("Continuing with `NOASSERTION` as a placeholder license.")
-		return "NOASSERTION"
+func (c Config) GetLicense() string {
+	if len(c.License) == 0 {
+		c.License = "NOASSERTION"
+		PrintMissingField("license", "go/hover.yaml", c.License)
 	}
-	return c.license
-}
-
-func (c Config) Author() string {
-	author := pubspec.GetPubSpec().Author
-	if author == "" {
-		log.Warnf("Missing author field in pubspec.yaml")
-		log.Warnf("Please add the `author` field to your pubspec.yaml")
-		u, err := user.Current()
-		if err != nil {
-			log.Errorf("Couldn't get current user: %v", err)
-			os.Exit(1)
-		}
-		author = u.Username
-		log.Printf("Using this username from system instead: %s", author)
-	}
-	return author
+	return c.License
 }
 
 var config = Config{}
@@ -120,4 +100,8 @@ func ReadConfigFile(configPath string) (*Config, error) {
 		return nil, errors.Wrap(err, "Failed to decode hover.yaml")
 	}
 	return &config, nil
+}
+
+func PrintMissingField(name, file, def string) {
+	log.Warnf("Missing/Empty `%s` field in %s. Please add it or otherwise you may publish your app with a wrong %s. Continuing with `%s` as a placeholder %s.", name, file, name, def, name)
 }

--- a/internal/pubspec/pubspec.go
+++ b/internal/pubspec/pubspec.go
@@ -2,7 +2,9 @@ package pubspec
 
 import (
 	"fmt"
+	"github.com/go-flutter-desktop/hover/internal/config"
 	"os"
+	"os/user"
 
 	"gopkg.in/yaml.v2"
 
@@ -18,6 +20,35 @@ type PubSpec struct {
 	Author       string
 	Dependencies map[string]interface{}
 	Flutter      map[string]interface{}
+}
+
+func (p PubSpec) GetDescription() string {
+	if len(p.Description) == 0 {
+		p.Description = "A flutter app made with go-flutter"
+		config.PrintMissingField("description", "pubspec.yaml", p.Description)
+	}
+	return p.Description
+}
+
+func (p PubSpec) GetVersion() string {
+	if len(p.Version) == 0 {
+		p.Version = "0.0.1"
+		config.PrintMissingField("version", "pubspec.yaml", p.Version)
+	}
+	return p.Version
+}
+
+func (p PubSpec) GetAuthor() string {
+	if len(p.Author) == 0 {
+		u, err := user.Current()
+		if err != nil {
+			log.Errorf("Couldn't get current user: %v", err)
+			os.Exit(1)
+		}
+		p.Author = u.Username
+		config.PrintMissingField("author", "pubspec.yaml", p.Author)
+	}
+	return p.Author
 }
 
 var pubspec = PubSpec{}


### PR DESCRIPTION
* Fixes https://github.com/go-flutter-desktop/go-flutter/issues/412.
* Fixes missing version and depdency fields in pubspec.yaml which are not necessary for packages that aren't uploaded to https://pub.dev (https://dart.dev/tools/pub/pubspec).
* Adds nicer output for information about a missing field.