### PR TITLE
fix build ignoring the cache-path

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -51,7 +51,7 @@ func init() {
 	buildCmd.PersistentFlags().StringVarP(&buildTarget, "target", "t", config.BuildTargetDefault, "The main entry-point file of the application.")
 	buildCmd.PersistentFlags().StringVarP(&buildGoFlutterBranch, "branch", "b", config.BuildBranchDefault, "The 'go-flutter' version to use. (@master or @v0.20.0 for example)")
 	buildCmd.PersistentFlags().StringVar(&buildEngineVersion, "engine-version", config.BuildEngineDefault, "The flutter engine version to use.")
-	buildCmd.PersistentFlags().StringVar(&buildCachePath, "cache-path", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+	buildCmd.PersistentFlags().StringVar(&buildCachePath, "cache-path", enginecache.DefaultCachePath(), "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
 	buildCmd.PersistentFlags().StringVar(&buildOpenGlVersion, "opengl", config.BuildOpenGlVersionDefault, "The OpenGL version specified here is only relevant for external texture plugin (i.e. video_plugin).\nIf 'none' is provided, texture won't be supported. Note: the Flutter Engine still needs a OpenGL compatible context.")
 	buildCmd.PersistentFlags().StringVar(&buildVersionNumber, "version-number", "", "Override the version number used in build and packaging. You may use it with $(git describe --tags)")
 	buildCmd.PersistentFlags().BoolVar(&buildDebug, "debug", false, "Build a debug version of the app.")
@@ -229,7 +229,7 @@ func initBuildParameters(targetOS string) {
 	if buildSkipEngineDownload {
 		engineCachePath = enginecache.EngineCachePath(targetOS, buildCachePath)
 	} else {
-		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS, buildEngineVersion)
+		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath, buildEngineVersion)
 	}
 }
 

--- a/cmd/bumpversion.go
+++ b/cmd/bumpversion.go
@@ -16,7 +16,7 @@ import (
 )
 
 func init() {
-	upgradeCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", "", "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
+	upgradeCmd.Flags().StringVarP(&buildCachePath, "cache-path", "", enginecache.DefaultCachePath(), "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll (defaults to the standard user cache directory)")
 	upgradeCmd.Flags().MarkHidden("branch")
 	rootCmd.AddCommand(upgradeCmd)
 }
@@ -37,13 +37,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 func upgrade(targetOS string) (err error) {
-	var engineCachePath string
-	if buildCachePath != "" {
-		engineCachePath = enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath, "")
-	} else {
-		engineCachePath = enginecache.ValidateOrUpdateEngine(targetOS, "")
-	}
-	return upgradeGoFlutter(targetOS, engineCachePath)
+	return upgradeGoFlutter(targetOS, enginecache.ValidateOrUpdateEngineAtPath(targetOS, buildCachePath, ""))
 }
 
 func upgradeGoFlutter(targetOS string, engineCachePath string) (err error) {

--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -358,11 +358,3 @@ func ValidateOrUpdateEngineAtPath(targetOS, cachePath, requiredEngineVersion str
 
 	return engineCachePath
 }
-
-// ValidateOrUpdateEngine validates the engine we have cached matches the
-// flutter version, or otherwise downloads a new engine. The returned path is
-// that of the engine location.
-func ValidateOrUpdateEngine(targetOS string, requiredEngineVersion string) (engineCachePath string) {
-	engineCachePath = ValidateOrUpdateEngineAtPath(targetOS, DefaultCachePath(), requiredEngineVersion)
-	return
-}


### PR DESCRIPTION
- ensures the cache-path cmd arguments always have a default.
- delete the convience helper as its not longer used.