### PR TITLE
fix: cgo ld directory not found

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -462,7 +462,7 @@ func buildEnv(targetOS string, engineCachePath string) []string {
 	var cgoLdflags string
 	var cgoCflags string
 
-	outputDirPath := filepath.Join("build", "outputs", targetOS)
+	outputDirPath := build.OutputDirectoryPath(targetOS)
 
 	switch targetOS {
 	case "darwin":


### PR DESCRIPTION
I try `hover run` in my fijkplayer project.
But ld can't find the library.

```
hover: ⚠ The go-flutter project tries to stay compatible with the beta channel of Flutter.
hover: ⚠     It's advised to use the beta channel: `flutter channel beta`
hover: Building flutter bundle
hover: Using engine from cache
hover: Compiling 'go-flutter' and plugins
github.com/befovy/fijkplayer/go
# github.com/befovy/fijkplayer/go
ld: warning: directory not found for option '-Lbuild/outputs/darwin'
ld: warning: directory not found for option '-Fbuild/outputs/darwin'
ld: library not found for -lIjkPlayer
clang: error: linker command failed with exit code 1 (use -v to see invocation)
hover: Go build failed: exit status 2
```

This pr fixes it