### PR TITLE
merge env CGO flags with additional hover CGO flags

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -461,17 +461,17 @@ func buildGoBinary(targetOS string, vmArguments []string) {
 }
 
 func buildEnv(targetOS string, engineCachePath string) []string {
-	var cgoLdflags string
-	var cgoCflags string
+	var cgoLdflags string = os.Getenv("CGO_LDFLAGS")
+	var cgoCflags string = os.Getenv("CGO_CFLAGS")
 
 	outputDirPath := build.OutputDirectoryPath(targetOS)
 
 	switch targetOS {
 	case "darwin":
-		cgoLdflags = fmt.Sprintf("-F%s -Wl,-rpath,@executable_path", engineCachePath)
+		cgoLdflags += fmt.Sprintf(" -F%s -Wl,-rpath,@executable_path", engineCachePath)
 		cgoLdflags += fmt.Sprintf(" -F%s -L%s", outputDirPath, outputDirPath)
 		cgoLdflags += " -mmacosx-version-min=10.10"
-		cgoCflags = "-mmacosx-version-min=10.10"
+		cgoCflags += " -mmacosx-version-min=10.10"
 	case "linux":
 		cgoLdflags = fmt.Sprintf("-L%s -L%s", engineCachePath, outputDirPath)
 	case "windows":


### PR DESCRIPTION
When building the CGO_CFLAGS and CGO_LDFLAGS start with the systems current env values. Without this it's impossible to link with shared libs.