### PR TITLE
Update README.md to set Env var using 'go env'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run `go version` and make sure that your Go version is 1.13 or higher.
 Then install hover by running this in your home directory:
 
 ```bash
-GO111MODULE=on go get -u -a github.com/go-flutter-desktop/hover
+go env -w GO111MODULE=on && go get -u -a github.com/go-flutter-desktop/hover
 ```
 Make sure the hover binary is on your `PATH`
 


### PR DESCRIPTION
Env variable is now set with 'go env' (cross platform).