### PR TITLE
Improve missing packaging tools instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,9 @@ RUN sed -i "s/#XferCommand/XferCommand/g" /etc/pacman.conf
 # This makes makepkg believe we are not root. Bypassing the root check is ok, because we are in a container
 ENV EUID=1
 
+# Create symlink for darwin-dmg
+RUN ln -s $(which genisoimage) /usr/bin/mkisofs
+
 COPY --from=flutterbuilder /opt/flutter /opt/flutter
 RUN ln -sf /opt/flutter/bin/flutter /usr/bin/flutter
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -245,9 +245,9 @@ func subcommandBuild(targetOS string, packagingTask packaging.Task, vmArguments 
 			buildGoBinary(targetOS, vmArguments)
 		}
 		if packagingTask != packaging.NoopTask {
-			log.Infof("Packaging app for %s-%s", targetOS, packagingTask.Name())
+			log.Infof("Packaging app for %s", packagingTask.Name())
 			packagingTask.Pack(buildVersionNumber, buildOrRunMode)
-			log.Infof("Successfully packaged app for %s-%s", targetOS, packagingTask.Name())
+			log.Infof("Successfully packaged app for %s", packagingTask.Name())
 		}
 	}
 }

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -91,7 +91,7 @@ func dockerHoverBuild(targetOS string, packagingTask packaging.Task, buildFlags 
 	dockerArgs = append(dockerArgs, dockerImage)
 	targetOSAndPackaging := targetOS
 	if packName := packagingTask.Name(); packName != "" {
-		targetOSAndPackaging += "-" + packName
+		targetOSAndPackaging = packName
 	}
 	hoverCommand := []string{"hover-safe.sh", "build", targetOSAndPackaging}
 	hoverCommand = append(hoverCommand, buildFlags...)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
+	"github.com/go-flutter-desktop/hover/cmd/packaging"
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/config"
 	"github.com/go-flutter-desktop/hover/internal/flutterversion"
@@ -37,6 +38,24 @@ var doctorCmd = &cobra.Command{
 
 		version := hoverVersion()
 		log.Infof("Hover version %s running on %s", version, runtime.GOOS)
+
+		log.Infof("Sharing packaging tools")
+		for _, task := range []packaging.Task{
+			packaging.DarwinBundleTask,
+			packaging.DarwinDmgTask,
+			packaging.DarwinPkgTask,
+			packaging.LinuxAppImageTask,
+			packaging.LinuxDebTask,
+			packaging.LinuxPkgTask,
+			packaging.LinuxRpmTask,
+			packaging.LinuxSnapTask,
+			packaging.WindowsMsiTask,
+		} {
+			if task.IsSupported() {
+				log.Infof("%s is supported", task.Name())
+			}
+		}
+		log.Printf("")
 
 		log.Infof("Sharing flutter version")
 		cmdFlutterVersion := exec.Command(build.FlutterBin(), "--version")

--- a/cmd/packaging/darwin-bundle.go
+++ b/cmd/packaging/darwin-bundle.go
@@ -48,7 +48,7 @@ var DarwinBundleTask = &packagingTask{
 
 		return outputFileName, nil
 	},
-	requiredTools: map[string][]string{
+	requiredTools: map[string]map[string]string{
 		"linux":   {},
 		"darwin":  {},
 		"windows": {},

--- a/cmd/packaging/darwin-dmg.go
+++ b/cmd/packaging/darwin-dmg.go
@@ -31,25 +31,31 @@ var DarwinDmgTask = &packagingTask{
 			return "", err
 		}
 
-		var cmdGenisoimage *exec.Cmd
+		var cmdCreateBundle *exec.Cmd
 		switch os := runtime.GOOS; os {
 		case "darwin":
-			cmdGenisoimage = exec.Command("hdiutil", "create", "-volname", packageName, "-srcfolder", "dmgdir", "-ov", "-format", "UDBZ", outputFileName)
+			cmdCreateBundle = exec.Command("hdiutil", "create", "-volname", packageName, "-srcfolder", "dmgdir", "-ov", "-format", "UDBZ", outputFileName)
 		case "linux":
-			cmdGenisoimage = exec.Command("genisoimage", "-V", packageName, "-D", "-R", "-apple", "-no-pad", "-o", outputFileName, "dmgdir")
+			cmdCreateBundle = exec.Command("mkisofs", "-V", packageName, "-D", "-R", "-apple", "-no-pad", "-o", outputFileName, "dmgdir")
 		}
-		cmdGenisoimage.Dir = tmpPath
-		cmdGenisoimage.Stdout = os.Stdout
-		cmdGenisoimage.Stderr = os.Stderr
-		err = cmdGenisoimage.Run()
+		cmdCreateBundle.Dir = tmpPath
+		cmdCreateBundle.Stdout = os.Stdout
+		cmdCreateBundle.Stderr = os.Stderr
+		err = cmdCreateBundle.Run()
 		if err != nil {
 			return "", err
 		}
 		return outputFileName, nil
 	},
 	skipAssertInitialized: true,
-	requiredTools: map[string][]string{
-		"linux":  {"ln", "genisoimage"},
-		"darwin": {"ln", "hdiutil"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"ln":      "Install ln from your package manager",
+			"mkisofs": "Install mkisofs from your package manager. Some distros ship genisoimage which is a fork of mkisofs. Create a symlink for it like this: ln -s $(which genisoimage) /usr/bin/mkisofs",
+		},
+		"darwin": {
+			"ln":      "Install ln from your package manager",
+			"hdiutil": "Install hdiutil from your package manager",
+		},
 	},
 }

--- a/cmd/packaging/darwin-pkg.go
+++ b/cmd/packaging/darwin-pkg.go
@@ -115,8 +115,20 @@ var DarwinPkgTask = &packagingTask{
 		}
 		return outputFileName, nil
 	},
-	requiredTools: map[string][]string{
-		"linux":  {"find", "cpio", "gzip", "mkbom", "xar"},
-		"darwin": {"find", "cpio", "gzip", "mkbom", "xar"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"find":  "Install find from your package manager",
+			"cpio":  "Install cpio from your package manager",
+			"gzip":  "Install gzip from your package manager",
+			"mkbom": "Install bomutils from your package manager or from https://github.com/hogliux/bomutils",
+			"xar":   "Install xar from your package manager or from https://github.com/mackyle/xar",
+		},
+		"darwin": {
+			"find":  "Install find from your package manager",
+			"cpio":  "Install cpio from your package manager",
+			"gzip":  "Install gzip from your package manager",
+			"mkbom": "Install bomutils from your package manager or from https://github.com/hogliux/bomutils",
+			"xar":   "Install xar from your package manager or from https://github.com/mackyle/xar",
+		},
 	},
 }

--- a/cmd/packaging/linux-appimage.go
+++ b/cmd/packaging/linux-appimage.go
@@ -61,7 +61,9 @@ var LinuxAppImageTask = &packagingTask{
 		}
 		return fmt.Sprintf("%s-%s-x86_64.AppImage", strings.ReplaceAll(applicationName, " ", "_"), version), nil
 	},
-	requiredTools: map[string][]string{
-		"linux": {"appimagetool"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"appimagetool": "Install appimagetool from your package manager or from https://github.com/AppImage/AppImageKit#appimagetool-usage",
+		},
 	},
 }

--- a/cmd/packaging/linux-deb.go
+++ b/cmd/packaging/linux-deb.go
@@ -33,7 +33,9 @@ var LinuxDebTask = &packagingTask{
 		}
 		return outputFileName, nil
 	},
-	requiredTools: map[string][]string{
-		"linux": {"dpkg-deb"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"makepkg": "You need to be on Debian, Ubuntu or another distro that uses apt/dpkg as package manager to use this. Installing dpkg on other distros is hard and dangerous.",
+		},
 	},
 }

--- a/cmd/packaging/linux-pkg.go
+++ b/cmd/packaging/linux-pkg.go
@@ -34,7 +34,9 @@ var LinuxPkgTask = &packagingTask{
 		}
 		return fmt.Sprintf("%s-%s-%s-x86_64%s", packageName, version, release, extension), nil
 	},
-	requiredTools: map[string][]string{
-		"linux": {"makepkg"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"makepkg": "You need to be on Arch Linux or another distro that uses pacman as package manager to use this. Installing makepkg on other distros is hard and dangerous.",
+		},
 	},
 }

--- a/cmd/packaging/linux-rpm.go
+++ b/cmd/packaging/linux-rpm.go
@@ -32,7 +32,9 @@ var LinuxRpmTask = &packagingTask{
 		}
 		return fmt.Sprintf("RPMS/x86_64/%s-%s-%s.x86_64.rpm", packageName, version, release), nil
 	},
-	requiredTools: map[string][]string{
-		"linux": {"rpmbuild"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"rpmbuild": "You need to be on Red Hat Linux or another distro that uses rpm as package manager to use this. Installing rpmbuild on other distros is hard and dangerous.",
+		},
 	},
 }

--- a/cmd/packaging/linux-snap.go
+++ b/cmd/packaging/linux-snap.go
@@ -27,7 +27,9 @@ var LinuxSnapTask = &packagingTask{
 		}
 		return fmt.Sprintf("%s_%s_amd64.snap", packageName, version), nil
 	},
-	requiredTools: map[string][]string{
-		"linux": {"snapcraft"},
+	requiredTools: map[string]map[string]string{
+		"linux": {
+			"snapcraft": "Install snapd from your package manager or from https://snapcraft.io/docs/installing-snapd",
+		},
 	},
 }

--- a/cmd/packaging/noop.go
+++ b/cmd/packaging/noop.go
@@ -11,4 +11,5 @@ func (_ *noopTask) Init()                   {}
 func (_ *noopTask) IsInitialized() bool     { return true }
 func (_ *noopTask) AssertInitialized()      {}
 func (_ *noopTask) Pack(string, build.Mode) {}
+func (_ *noopTask) IsSupported() bool       { return true }
 func (_ *noopTask) AssertSupported()        {}

--- a/cmd/packaging/task.go
+++ b/cmd/packaging/task.go
@@ -10,5 +10,6 @@ type Task interface {
 	IsInitialized() bool
 	AssertInitialized()
 	Pack(buildVersion string, mode build.Mode)
+	IsSupported() bool
 	AssertSupported()
 }

--- a/cmd/packaging/windows-msi.go
+++ b/cmd/packaging/windows-msi.go
@@ -93,9 +93,13 @@ var WindowsMsiTask = &packagingTask{
 		}
 		return outputFileName, nil
 	},
-	requiredTools: map[string][]string{
-		"windows": {"candle", "light"},
-		"linux":   {"wixl"},
+	requiredTools: map[string]map[string]string{
+		"windows": {
+			"candle": "Install the WiX Toolset from https://wixtoolset.org/releases/", // Only for one tool, because displaying the message twice makes no sense
+		},
+		"linux": {
+			"wixl": "Install msitools from your package manager or from https://wiki.gnome.org/msitools/",
+		},
 	},
 	generateInitFiles: func(packageName, path string) {
 		b := make([]byte, 16)


### PR DESCRIPTION
Closes https://github.com/go-flutter-desktop/go-flutter/issues/523
The new output of `hover doctor`:
```log
hover: Hover version (devel) running on linux
hover: Sharing packaging tools
hover: darwin-bundle is supported
hover: darwin-dmg is supported
hover: darwin-pkg is supported
hover: To package linux-appimage these tools are required: appimagetool
hover: Install appimagetool from your package manager or from https://github.com/AppImage/AppImageKit#appimagetool-usage
hover: To still package linux-appimage without the required tools installed you need to run hover with the `--docker` flag.
hover: linux-deb is supported
hover: linux-pkg is supported
hover: linux-rpm is supported
hover: To package linux-snap these tools are required: snapcraft
hover: Install snapd from your package manager or from https://snapcraft.io/docs/installing-snapd
hover: To still package linux-snap without the required tools installed you need to run hover with the `--docker` flag.
hover: To package windows-msi these tools are required: wixl
hover: Install msitools from your package manager or from https://wiki.gnome.org/msitools/
hover: To still package windows-msi without the required tools installed you need to run hover with the `--docker` flag.
hover: 
hover: Sharing flutter version
...
```

The new output of `hover build [unsupported]`:
```log
hover: Downloading engine for platform windows-debug_unopt at version 1bc025d6cbf1136c2e96c6fb041d24202ea47ff0...
Download completed in 28.32s
hover: To package windows-msi these tools are required: wixl
hover: Install msitools from your package manager or from https://wiki.gnome.org/msitools/
hover: To still package windows-msi without the required tools installed you need to run hover with the `--docker` flag.
```

The output is a bit messy, but clear enough to find issues.