### PR TITLE
Add automatic and manual cache invalidation

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -8,8 +8,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/go-flutter-desktop/hover/internal/enginecache"
-
 	"github.com/hashicorp/go-version"
 	"github.com/otiai10/copy"
 	"github.com/spf13/cobra"
@@ -18,9 +16,11 @@ import (
 	"github.com/go-flutter-desktop/hover/internal/androidmanifest"
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/config"
+	"github.com/go-flutter-desktop/hover/internal/enginecache"
 	"github.com/go-flutter-desktop/hover/internal/fileutils"
 	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/go-flutter-desktop/hover/internal/pubspec"
+	internalVersion "github.com/go-flutter-desktop/hover/internal/version"
 	"github.com/go-flutter-desktop/hover/internal/versioncheck"
 )
 
@@ -576,7 +576,7 @@ func buildGoBinary(targetOS string, vmArguments []string) {
 		}
 	}
 
-	versioncheck.CheckForHoverUpdate(hoverVersion())
+	versioncheck.CheckForHoverUpdate(internalVersion.HoverVersion())
 
 	if buildOrRunOpenGlVersion == "none" {
 		log.Warnf("The '--opengl=none' flag makes go-flutter incompatible with texture plugins!")

--- a/cmd/clean-cache.go
+++ b/cmd/clean-cache.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/go-flutter-desktop/hover/internal/enginecache"
+	"github.com/go-flutter-desktop/hover/internal/log"
+)
+
+var cachePath string
+
+func init() {
+	cleanCacheCmd.Flags().StringVar(&cachePath, "cache-path", enginecache.DefaultCachePath(), "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll")
+	rootCmd.AddCommand(cleanCacheCmd)
+}
+
+var cleanCacheCmd = &cobra.Command{
+	Use:   "clean-cache",
+	Short: "Clean cached engine files",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return errors.New("does not take arguments")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := os.RemoveAll(enginecache.BaseEngineCachePath(cachePath))
+		if err != nil {
+			log.Errorf("Failed to delete engine cache directory: %v", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -14,9 +14,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/go-flutter-desktop/hover/internal/build"
-	"github.com/go-flutter-desktop/hover/internal/flutterversion"
 	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/go-flutter-desktop/hover/internal/pubspec"
+	"github.com/go-flutter-desktop/hover/internal/version"
 )
 
 // assertInFlutterProject asserts this command is executed in a flutter project
@@ -48,7 +48,7 @@ func assertHoverInitialized() {
 }
 
 func checkFlutterChannel() {
-	channel := flutterversion.FlutterChannel()
+	channel := version.FlutterChannel()
 	ignoreWarning := os.Getenv("HOVER_IGNORE_CHANNEL_WARNING")
 	if channel != "beta" && ignoreWarning != "true" {
 		log.Warnf("⚠ The go-flutter project tries to stay compatible with the beta channel of Flutter.")

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/go-flutter-desktop/hover/internal/logstreamer"
+	"github.com/go-flutter-desktop/hover/internal/version"
 )
 
 func dockerHoverBuild(targetOS string, packagingTask packaging.Task, buildFlags []string, vmArguments []string) {
@@ -83,11 +84,11 @@ func dockerHoverBuild(targetOS string, packagingTask packaging.Task, buildFlags 
 		dockerArgs = append(dockerArgs, "--env", "HOVER_IN_DOCKER_BUILD_VMARGS="+strings.Join(vmArguments, ","))
 	}
 
-	version := hoverVersion()
-	if version == "(devel)" {
-		version = "latest"
+	hoverVersion := version.HoverVersion()
+	if hoverVersion == "(devel)" {
+		hoverVersion = "latest"
 	}
-	dockerImage := "goflutter/hover:" + version
+	dockerImage := "goflutter/hover:" + hoverVersion
 	dockerArgs = append(dockerArgs, dockerImage)
 	targetOSAndPackaging := targetOS
 	if packName := packagingTask.Name(); packName != "" {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/config"
-	"github.com/go-flutter-desktop/hover/internal/flutterversion"
 	"github.com/go-flutter-desktop/hover/internal/log"
+	"github.com/go-flutter-desktop/hover/internal/version"
 )
 
 func init() {
@@ -35,8 +35,8 @@ var doctorCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		assertInFlutterProject()
 
-		version := hoverVersion()
-		log.Infof("Hover version %s running on %s", version, runtime.GOOS)
+		hoverVersion := version.HoverVersion()
+		log.Infof("Hover version %s running on %s", hoverVersion, runtime.GOOS)
 
 		log.Infof("Sharing flutter version")
 		cmdFlutterVersion := exec.Command(build.FlutterBin(), "--version")
@@ -47,7 +47,7 @@ var doctorCmd = &cobra.Command{
 			log.Errorf("Flutter --version failed: %v", err)
 		}
 
-		engineCommitHash := flutterversion.FlutterRequiredEngineVersion()
+		engineCommitHash := version.FlutterRequiredEngineVersion()
 		log.Infof("Flutter engine commit: %s", log.Au().Magenta("https://github.com/flutter/engine/commit/"+engineCommitHash))
 
 		checkFlutterChannel()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,13 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"runtime/debug"
-	"sync"
-
-	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/go-flutter-desktop/hover/internal/version"
 )
 
 func init() {
@@ -25,24 +22,7 @@ var versionCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		version := hoverVersion()
+		version := version.HoverVersion()
 		fmt.Printf("Hover %s\n", version)
 	},
-}
-
-var (
-	hoverVersionValue string
-	hoverVersionOnce  sync.Once
-)
-
-func hoverVersion() string {
-	hoverVersionOnce.Do(func() {
-		buildInfo, ok := debug.ReadBuildInfo()
-		if !ok {
-			log.Errorf("Cannot obtain version information from hover build. To resolve this, please go-get hover using Go 1.13 or newer.")
-			os.Exit(1)
-		}
-		hoverVersionValue = buildInfo.Main.Version
-	})
-	return hoverVersionValue
 }

--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/go-flutter-desktop/hover/internal/build"
-	"github.com/go-flutter-desktop/hover/internal/flutterversion"
 	"github.com/go-flutter-desktop/hover/internal/log"
+	"github.com/go-flutter-desktop/hover/internal/version"
 )
 
 func createSymLink(oldname, newname string) error {
@@ -173,7 +173,11 @@ func EngineConfig(targetOS string, mode build.Mode) string {
 
 //noinspection GoNameStartsWithPackageName
 func EngineCachePath(targetOS, cachePath string, mode build.Mode) string {
-	return filepath.Join(cachePath, "hover", "engine", EngineConfig(targetOS, mode))
+	return filepath.Join(BaseEngineCachePath(cachePath), EngineConfig(targetOS, mode))
+}
+
+func BaseEngineCachePath(cachePath string) string {
+	return filepath.Join(cachePath, "hover", "engine")
 }
 
 // ValidateOrUpdateEngine validates the engine we have cached matches the
@@ -198,10 +202,10 @@ func ValidateOrUpdateEngine(targetOS, cachePath, requiredEngineVersion string, m
 	}
 	cachedEngineVersion := string(cachedEngineVersionBytes)
 	if len(requiredEngineVersion) == 0 {
-		requiredEngineVersion = flutterversion.FlutterRequiredEngineVersion()
+		requiredEngineVersion = version.FlutterRequiredEngineVersion()
 	}
 
-	if cachedEngineVersion == requiredEngineVersion {
+	if cachedEngineVersion == fmt.Sprintf("%s-%s", requiredEngineVersion, version.HoverVersion()) {
 		log.Printf("Using engine from cache")
 		return
 	} else {
@@ -301,7 +305,7 @@ func ValidateOrUpdateEngine(targetOS, cachePath, requiredEngineVersion string, m
 		}
 	}
 
-	err = ioutil.WriteFile(cachedEngineVersionPath, []byte(requiredEngineVersion), 0664)
+	err = ioutil.WriteFile(cachedEngineVersionPath, []byte(fmt.Sprintf("%s-%s", requiredEngineVersion, version.HoverVersion())), 0664)
 	if err != nil {
 		log.Errorf("Failed to write version file: %v", err)
 		os.Exit(1)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,10 +1,12 @@
-package flutterversion
+package version
 
 import (
 	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
+	"runtime/debug"
+	"sync"
 
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/log"
@@ -55,4 +57,21 @@ func readFlutterVersion() flutterVersionResponse {
 type flutterVersionResponse struct {
 	Channel        string
 	EngineRevision string
+}
+
+var (
+	hoverVersionValue string
+	hoverVersionOnce  sync.Once
+)
+
+func HoverVersion() string {
+	hoverVersionOnce.Do(func() {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			log.Errorf("Cannot obtain version information from hover build. To resolve this, please go-get hover using Go 1.13 or newer.")
+			os.Exit(1)
+		}
+		hoverVersionValue = buildInfo.Main.Version
+	})
+	return hoverVersionValue
 }


### PR DESCRIPTION
Fixes cache nonsense that came along with #147 and #170. Simply appends the hover version to the engine commit hash.