### PR TITLE
remove force env overwritten

### DIFF
--- a/cmd/bumpversion.go
+++ b/cmd/bumpversion.go
@@ -53,10 +53,6 @@ func upgradeGoFlutter(targetOS string) (err error) {
 
 	cmdGoGetU := exec.Command(build.GoBin(), "get", "-u", "-d", "github.com/go-flutter-desktop/go-flutter"+buildOrRunGoFlutterBranch)
 	cmdGoGetU.Dir = filepath.Join(wd, build.BuildPath)
-	cmdGoGetU.Env = append(os.Environ(),
-		"GOPROXY=direct", // github.com/golang/go/issues/32955 (allows '/' in branch name)
-		"GO111MODULE=on",
-	)
 	cmdGoGetU.Stderr = os.Stderr
 	cmdGoGetU.Stdout = os.Stdout
 

--- a/cmd/bumpversion.go
+++ b/cmd/bumpversion.go
@@ -52,6 +52,9 @@ func upgradeGoFlutter(targetOS string) (err error) {
 	}
 
 	cmdGoGetU := exec.Command(build.GoBin(), "get", "-u", "-d", "github.com/go-flutter-desktop/go-flutter"+buildOrRunGoFlutterBranch)
+	cmdGoGetU.Env = append(os.Environ(),
+		"GO111MODULE=on",
+	)
 	cmdGoGetU.Dir = filepath.Join(wd, build.BuildPath)
 	cmdGoGetU.Stderr = os.Stderr
 	cmdGoGetU.Stdout = os.Stdout


### PR DESCRIPTION
https://github.com/go-flutter-desktop/go-flutter/issues/555

goproxy should not force overwritten, as it will make users in China confuse as they cannot easily access golangorg