### PR TITLE
enable users to prepare the flutter engine within docker image without building first.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,6 @@ COPY docker/hover-safe.sh /usr/local/bin/hover-safe.sh
 
 # Prepare engines
 RUN hover prepare-engine --all
-ENV CGO_LDFLAGS="-L/.cache/hover/engine/linux-release -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/darwin-release"
+ENV CGO_LDFLAGS="-L~/.cache/hover/engine/linux-release -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/darwin-release"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,12 @@ RUN go install -v ./... 2>&1
 COPY docker/hover-safe.sh /usr/local/bin/hover-safe.sh
 
 # Prepare engines
-ENV CGO_LDFLAGS="-L~/.cache/hover/engine/linux-release -L~/.cache/hover/engine/linux-debug_unopt -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/windows-debug_unopt -L~/.cache/hover/engine/darwin-debug_unopt"
+ENV CGO_LDFLAGS="-L~/.cache/hover/engine/linux-release"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/linux-debug_unopt"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/linux-profile"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/windows-release"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/windows-debug_unopt"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/windows-profile"
+ENV CGO_LDFLAGS="$CGO_LDFLAGS -L~/.cache/hover/engine/darwin-debug_unopt"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,6 @@ RUN go install -v ./... 2>&1
 COPY docker/hover-safe.sh /usr/local/bin/hover-safe.sh
 
 # Prepare engines
-RUN hover prepare-engine --all
-ENV CGO_LDFLAGS="-L~/.cache/hover/engine/linux-release -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/darwin-release"
+ENV CGO_LDFLAGS="-L~/.cache/hover/engine/linux-release -L~/.cache/hover/engine/linux-debug_unopt -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/windows-debug_unopt -L~/.cache/hover/engine/darwin-debug_unopt"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,4 +121,8 @@ RUN go install -v ./... 2>&1
 
 COPY docker/hover-safe.sh /usr/local/bin/hover-safe.sh
 
+# Prepare engines
+RUN hover prepare-engine --all
+ENV CGO_LDFLAGS="-L/.cache/hover/engine/linux-release -L~/.cache/hover/engine/windows-release -L~/.cache/hover/engine/darwin-release"
+
 WORKDIR /app

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -86,7 +86,7 @@ func validatePrepareEngineParameters(targetOS string) {
 		log.Errorf("Multiple target modes set. Please select exactly one from: debug, profile, release.")
 		os.Exit(1)
 	}
-	if targetOS == "darwin" && runtime.GOOS != targetOS && prepareReleaseMode {
+	if targetOS == "darwin" && runtime.GOOS != targetOS && (prepareReleaseMode || prepareProfileMode) {
 		log.Errorf("It is not possible to prepare the flutter engine in release mode for darwin using docker")
 		os.Exit(1)
 	}

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"os/exec"
 	"runtime"
 
 	"github.com/go-flutter-desktop/hover/internal/build"
@@ -88,10 +87,8 @@ func validatePrepareEngineParameters(targetOS string) {
 		os.Exit(1)
 	}
 	if targetOS == "darwin" && runtime.GOOS != targetOS && prepareReleaseMode {
-		if path, err := exec.LookPath("darling"); err != nil || len(path) == 0 {
-			log.Errorf("To prepare the release flutter engine for darwin on linux, install darling from your package manager or https://www.darlinghq.org/")
-			os.Exit(1)
-		}
+		log.Errorf("It is not possible to prepare the flutter engine in release mode for darwin using docker")
+		os.Exit(1)
 	}
 }
 

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -70,6 +70,6 @@ func initPrepareEngineParameters(targetOSes ...string) {
 
 func subcommandPrepare(targetOSes ...string) {
 	for _, targetOS := range targetOSes {
-		enginecache.ValidateOrUpdateEngine(targetOS, prepareCachePath, prepareEngineVersion, build.ReleaseMode)
+		enginecache.ValidateOrUpdateEngine(targetOS, prepareCachePath, prepareEngineVersion, build.DebugMode)
 	}
 }

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"runtime"
+
 	"github.com/go-flutter-desktop/hover/internal/build"
 	"github.com/go-flutter-desktop/hover/internal/config"
 	"github.com/go-flutter-desktop/hover/internal/enginecache"
 	"github.com/go-flutter-desktop/hover/internal/log"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
-	"runtime"
 )
 
 var (
@@ -16,14 +17,16 @@ var (
 	prepareEngineVersion string
 	prepareReleaseMode   bool
 	prepareDebugMode     bool
+	prepareProfileMode   bool
 	prepareBuildModes    []build.Mode
 )
 
 func init() {
 	prepareEngineCmd.PersistentFlags().StringVar(&prepareCachePath, "cache-path", enginecache.DefaultCachePath(), "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll")
 	prepareEngineCmd.PersistentFlags().StringVar(&prepareEngineVersion, "engine-version", config.BuildEngineDefault, "The flutter engine version to use.")
-	prepareEngineCmd.PersistentFlags().BoolVar(&prepareDebugMode, "debug-mode", true, "Prepare the flutter engine for debug mode")
-	prepareEngineCmd.PersistentFlags().BoolVar(&prepareReleaseMode, "release-mode", false, "Prepare the flutter engine for release mode")
+	prepareEngineCmd.PersistentFlags().BoolVar(&prepareDebugMode, "debug", false, "Prepare the flutter engine for debug mode")
+	prepareEngineCmd.PersistentFlags().BoolVar(&prepareReleaseMode, "release", false, "Prepare the flutter engine for release mode.")
+	prepareEngineCmd.PersistentFlags().BoolVar(&prepareProfileMode, "profile", false, "Prepare the flutter engine for profile mode.")
 	prepareEngineCmd.AddCommand(prepareEngineLinuxCmd)
 	prepareEngineCmd.AddCommand(prepareEngineDarwinCmd)
 	prepareEngineCmd.AddCommand(prepareEngineWindowsCmd)
@@ -63,16 +66,27 @@ var prepareEngineWindowsCmd = &cobra.Command{
 }
 
 func initPrepareEngineParameters(targetOS string) {
+	validatePrepareEngineParameters(targetOS)
 	if prepareDebugMode {
 		prepareBuildModes = append(prepareBuildModes, build.DebugMode)
 	}
 	if prepareReleaseMode {
 		prepareBuildModes = append(prepareBuildModes, build.ReleaseMode)
 	}
-	validatePrepareEngineParameters(targetOS)
+	if prepareProfileMode {
+		prepareBuildModes = append(prepareBuildModes, build.ProfileMode)
+	}
 }
 
 func validatePrepareEngineParameters(targetOS string) {
+	if !prepareDebugMode && !prepareReleaseMode && !prepareProfileMode {
+		log.Errorf("No target mode set. Please select exactly one from: debug, profile, release.")
+		os.Exit(1)
+	}
+	if (prepareDebugMode && prepareReleaseMode) || (prepareDebugMode && prepareProfileMode) || (prepareReleaseMode && prepareProfileMode) {
+		log.Errorf("Multiple target modes set. Please select exactly one from: debug, profile, release.")
+		os.Exit(1)
+	}
 	if targetOS == "darwin" && runtime.GOOS != targetOS && prepareReleaseMode {
 		if path, err := exec.LookPath("darling"); err != nil || len(path) == 0 {
 			log.Errorf("To prepare the release flutter engine for darwin on linux, install darling from your package manager or https://www.darlinghq.org/")

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"github.com/go-flutter-desktop/hover/internal/build"
+	"github.com/go-flutter-desktop/hover/internal/config"
+	"github.com/go-flutter-desktop/hover/internal/enginecache"
+	"github.com/go-flutter-desktop/hover/internal/log"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var (
+	prepareAllTargetOSes bool
+	prepareCachePath     string
+	prepareEngineVersion string
+)
+
+func init() {
+	prepareEngineCmd.PersistentFlags().BoolVar(&prepareAllTargetOSes, "all", false, "Prepare the flutter engine for all target operating systems")
+	prepareEngineCmd.PersistentFlags().StringVar(&prepareCachePath, "cache-path", enginecache.DefaultCachePath(), "The path that hover uses to cache dependencies such as the Flutter engine .so/.dll")
+	prepareEngineCmd.PersistentFlags().StringVar(&prepareEngineVersion, "engine-version", config.BuildEngineDefault, "The flutter engine version to use.")
+	prepareEngineCmd.AddCommand(prepareEngineLinuxCmd)
+	prepareEngineCmd.AddCommand(prepareEngineDarwinCmd)
+	prepareEngineCmd.AddCommand(prepareEngineWindowsCmd)
+	rootCmd.AddCommand(prepareEngineCmd)
+}
+
+var prepareEngineCmd = &cobra.Command{
+	Use:   "prepare-engine",
+	Short: "Validates or updates the flutter engine on this machine for a given platform",
+	Run: func(cmd *cobra.Command, args []string) {
+		initPrepareEngineParameters("darwin", "linux", "windows")
+		subcommandPrepare("linux", "windows", "darwin")
+	},
+}
+
+var prepareEngineLinuxCmd = &cobra.Command{
+	Use:   "linux",
+	Short: "Validates or updates the flutter engine on this machine for a given platform",
+	Run: func(cmd *cobra.Command, args []string) {
+		initPrepareEngineParameters("linux")
+		subcommandPrepare("linux")
+	},
+}
+
+var prepareEngineDarwinCmd = &cobra.Command{
+	Use:   "darwin",
+	Short: "Validates or updates the flutter engine on this machine for a given platform",
+	Run: func(cmd *cobra.Command, args []string) {
+		initPrepareEngineParameters("darwin")
+		subcommandPrepare("darwin")
+	},
+}
+
+var prepareEngineWindowsCmd = &cobra.Command{
+	Use:   "windows",
+	Short: "Validates or updates the flutter engine on this machine for a given platform",
+	Run: func(cmd *cobra.Command, args []string) {
+		initPrepareEngineParameters("windows")
+		subcommandPrepare("windows")
+	},
+}
+
+func initPrepareEngineParameters(targetOSes ...string) {
+	if len(targetOSes) == 0 && !prepareAllTargetOSes {
+		log.Errorf("missing target OS or --all, cannot continue.")
+		os.Exit(1)
+	}
+}
+
+func subcommandPrepare(targetOSes ...string) {
+	for _, targetOS := range targetOSes {
+		enginecache.ValidateOrUpdateEngine(targetOS, prepareCachePath, prepareEngineVersion, build.ReleaseMode)
+	}
+}

--- a/cmd/prepare-engine.go
+++ b/cmd/prepare-engine.go
@@ -78,13 +78,18 @@ func initPrepareEngineParameters(targetOS string) {
 }
 
 func validatePrepareEngineParameters(targetOS string) {
-	if !prepareDebugMode && !prepareReleaseMode && !prepareProfileMode {
-		log.Errorf("No target mode set. Please select exactly one from: debug, profile, release.")
+	numberOfPrepareModeFlagsSet := 0
+	for _, flag := range []bool{prepareProfileMode, prepareProfileMode, prepareDebugMode} {
+		if flag {
+			numberOfPrepareModeFlagsSet++
+		}
+	}
+	if numberOfPrepareModeFlagsSet > 1 {
+		log.Errorf("Only one of --debug, --release or --profile can be set at one time")
 		os.Exit(1)
 	}
-	if (prepareDebugMode && prepareReleaseMode) || (prepareDebugMode && prepareProfileMode) || (prepareReleaseMode && prepareProfileMode) {
-		log.Errorf("Multiple target modes set. Please select exactly one from: debug, profile, release.")
-		os.Exit(1)
+	if numberOfPrepareModeFlagsSet == 0 {
+		prepareDebugMode = true
 	}
 	if targetOS == "darwin" && runtime.GOOS != targetOS && (prepareReleaseMode || prepareProfileMode) {
 		log.Errorf("It is not possible to prepare the flutter engine in release mode for darwin using docker")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/otiai10/copy v1.5.1
+	github.com/otiai10/copy v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -67,7 +67,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -148,8 +147,6 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/otiai10/copy v1.5.1 h1:a/cs2E1/1V0az8K5nblbl+ymEa4E11AfaOLMar8V34w=
-github.com/otiai10/copy v1.5.1/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
@@ -198,7 +195,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -308,7 +304,6 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/otiai10/copy v1.5.1 h1:a/cs2E1/1V0az8K5nblbl+ymEa4E11AfaOLMar8V34w=
 github.com/otiai10/copy v1.5.1/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
+github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
+github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=


### PR DESCRIPTION
Fixes #598 

For the details of why this pull request was made, see https://github.com/go-flutter-desktop/go-flutter/issues/598