### PR TITLE
Switch to go-flutter-desktop engine builds, update snapshot generation

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -534,7 +534,6 @@ func buildFlutterBundle(targetOS string) {
 		}
 		generateAotSnapshotCommand := []string{
 			darwinhacks.RewriteDarlingPath(useDarling, genSnapshot),
-			"--no-causal-async-stacks",
 			"--lazy-async-stacks",
 			"--deterministic",
 			"--snapshot_kind=app-aot-elf",

--- a/internal/enginecache/cache.go
+++ b/internal/enginecache/cache.go
@@ -309,14 +309,14 @@ func ValidateOrUpdateEngine(targetOS, cachePath, requiredEngineVersion string, m
 			file += "windows"
 		}
 		file += fmt.Sprintf("_x64-host_%s.zip", mode.Name)
-		engineDownloadURL := fmt.Sprintf("https://github.com/flutter-rs/engine-builds/releases/download/f-%s/%s", requiredEngineVersion, file)
+		engineDownloadURL := fmt.Sprintf("https://github.com/go-flutter-desktop/engine-builds/releases/download/f-%s/%s", requiredEngineVersion, file)
 
 		err = downloadFile(engineZipPath, engineDownloadURL)
 		if err != nil {
 			log.Errorf("Failed to download engine: %v", err)
 			log.Errorf("Engine builds are a bit delayed after they are published in flutter.")
 			log.Errorf("You can either try again later or switch the flutter channel to beta, because these engines are more likely to be already built.")
-			log.Errorf("To dig into the already built engines look at https://github.com/flutter-rs/engine-builds/releases and https://github.com/flutter-rs/engine-builds/actions")
+			log.Errorf("To dig into the already built engines look at https://github.com/go-flutter-desktop/engine-builds/releases and https://github.com/go-flutter-desktop/engine-builds/actions")
 			os.Exit(1)
 		}
 		_, err = unzip(engineZipPath, engineExtractPath)


### PR DESCRIPTION
The --no-causal-async-stacks option is no longer present.